### PR TITLE
Fix location_code in volume creation

### DIFF
--- a/pkg/verda/instances_test.go
+++ b/pkg/verda/instances_test.go
@@ -134,10 +134,10 @@ func TestInstanceService_Create(t *testing.T) {
 			Pricing:         "FIXED_PRICE",
 			StartupScriptID: stringPtr("script_123"),
 			Volumes: []VolumeCreateRequest{
-				{Size: 500, Type: "SSD", Name: "data"},
+				{Size: 500, Type: VolumeTypeNVMe, Name: "data"},
 			},
 			ExistingVolumes: []string{"vol_123"},
-			OSVolume:        &OSVolumeCreateRequest{Size: 100, Type: "SSD"},
+			OSVolume:        &OSVolumeCreateRequest{Size: 100},
 			IsSpot:          true,
 			Coupon:          stringPtr("DISCOUNT20"),
 		}

--- a/pkg/verda/services_test.go
+++ b/pkg/verda/services_test.go
@@ -233,7 +233,7 @@ func TestVolumeService_Get(t *testing.T) {
 				ID:     "vol_123",
 				Name:   "Test Volume",
 				Size:   100,
-				Type:   "SSD",
+				Type:   VolumeTypeNVMe,
 				Status: "available",
 			},
 		}
@@ -275,7 +275,7 @@ func TestVolumeService_GetByID(t *testing.T) {
 			ID:     "vol_123",
 			Name:   "Specific Volume",
 			Size:   200,
-			Type:   "SSD",
+			Type:   VolumeTypeNVMe,
 			Status: "in-use",
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -79,7 +79,7 @@ type VolumeCreateRequest struct {
 	Size     int    `json:"size"`
 	Type     string `json:"type"`
 	Name     string `json:"name"`
-	Location string `json:"location,omitempty"`
+	Location string `json:"location_code,omitempty"`
 }
 
 // VolumeAttachRequest represents a request to attach a volume to an instance
@@ -95,7 +95,7 @@ type VolumeDetachRequest struct {
 // VolumeCloneRequest represents a request to clone a volume
 type VolumeCloneRequest struct {
 	Name     string `json:"name"`
-	Location string `json:"location,omitempty"`
+	Location string `json:"location_code,omitempty"`
 }
 
 // VolumeResizeRequest represents a request to resize a volume
@@ -112,7 +112,6 @@ type VolumeRenameRequest struct {
 type OSVolumeCreateRequest struct {
 	Name string `json:"name"`
 	Size int    `json:"size"`
-	Type string `json:"type"`
 }
 
 // InstanceActionRequest represents an action to perform on instances


### PR DESCRIPTION
Location code in volume creation had a wrong name, OS volumes had a non-existent type and some tests had a non-existent volume type. This PR fixes those issues.