### PR TITLE
Correct scaling object for serverless jobs

### DIFF
--- a/pkg/verda/serverless_jobs_test.go
+++ b/pkg/verda/serverless_jobs_test.go
@@ -107,7 +107,7 @@ func TestServerlessJobsService_CreateJobDeployment(t *testing.T) {
 				Name: "H100",
 				Size: 1,
 			},
-			Scaling: &ContainerScalingOptions{
+			Scaling: &JobScalingOptions{
 				MaxReplicaCount:        1,
 				QueueMessageTTLSeconds: 300,
 			},
@@ -152,7 +152,7 @@ func TestServerlessJobsService_GetJobDeploymentByName(t *testing.T) {
 				Name: "H100",
 				Size: 1,
 			},
-			Scaling: &ContainerScalingOptions{
+			Scaling: &JobScalingOptions{
 				MaxReplicaCount: 1,
 			},
 		}
@@ -189,7 +189,7 @@ func TestServerlessJobsService_DeleteJobDeployment(t *testing.T) {
 				Name: "H100",
 				Size: 1,
 			},
-			Scaling: &ContainerScalingOptions{
+			Scaling: &JobScalingOptions{
 				MaxReplicaCount: 1,
 			},
 		}
@@ -225,7 +225,7 @@ func TestServerlessJobsService_GetJobDeploymentStatus(t *testing.T) {
 				Name: "H100",
 				Size: 1,
 			},
-			Scaling: &ContainerScalingOptions{
+			Scaling: &JobScalingOptions{
 				MaxReplicaCount: 1,
 			},
 		}
@@ -261,7 +261,7 @@ func TestServerlessJobsService_JobOperations(t *testing.T) {
 				Name: "H100",
 				Size: 1,
 			},
-			Scaling: &ContainerScalingOptions{
+			Scaling: &JobScalingOptions{
 				MaxReplicaCount: 1,
 			},
 		}

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -759,7 +759,7 @@ type CreateJobDeploymentRequest struct {
 	ContainerRegistrySettings *ContainerRegistrySettings  `json:"container_registry_settings,omitempty"`
 	Containers                []CreateDeploymentContainer `json:"containers"`
 	Compute                   *ContainerCompute           `json:"compute,omitempty"`
-	Scaling                   *ContainerScalingOptions    `json:"scaling,omitempty"`
+	Scaling                   *JobScalingOptions          `json:"scaling,omitempty"`
 }
 
 // UpdateJobDeploymentRequest represents a request to update a job deployment
@@ -768,7 +768,7 @@ type UpdateJobDeploymentRequest struct {
 	ContainerRegistrySettings *ContainerRegistrySettings  `json:"container_registry_settings,omitempty"`
 	Containers                []CreateDeploymentContainer `json:"containers,omitempty"`
 	Compute                   *ContainerCompute           `json:"compute,omitempty"`
-	Scaling                   *ContainerScalingOptions    `json:"scaling,omitempty"`
+	Scaling                   *JobScalingOptions          `json:"scaling,omitempty"`
 }
 
 // JobScalingOptions represents scaling configuration for a job deployment


### PR DESCRIPTION
## Description

A wrong scaling object type was accidentally put in place when I refactored types to more heavily typed instead of generics. This PR fixes it.

## Type of Change

Change of scaling object type for CreateJobDeploymentRequest and UpdateJobDeploymentRequest.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ✅ Test updates


