### PR TITLE
Use correct type in serverless job scaling rule endpoints

### DIFF
--- a/pkg/verda/serverless_jobs.go
+++ b/pkg/verda/serverless_jobs.go
@@ -80,19 +80,19 @@ func (s *ServerlessJobsService) DeleteJobDeployment(ctx context.Context, jobName
 	return err
 }
 
-func (s *ServerlessJobsService) GetJobDeploymentScaling(ctx context.Context, jobName string) (*ContainerScalingOptions, error) {
+func (s *ServerlessJobsService) GetJobDeploymentScaling(ctx context.Context, jobName string) (*JobScalingOptions, error) {
 	if jobName == "" {
 		return nil, fmt.Errorf("jobName is required")
 	}
 	path := fmt.Sprintf("/job-deployments/%s/scaling", jobName)
-	scaling, _, err := getRequest[ContainerScalingOptions](ctx, s.client, path)
+	scaling, _, err := getRequest[JobScalingOptions](ctx, s.client, path)
 	if err != nil {
 		return nil, err
 	}
 	return &scaling, nil
 }
 
-func (s *ServerlessJobsService) UpdateJobDeploymentScaling(ctx context.Context, jobName string, req *UpdateScalingOptionsRequest) (*ContainerScalingOptions, error) {
+func (s *ServerlessJobsService) UpdateJobDeploymentScaling(ctx context.Context, jobName string, req *UpdateScalingOptionsRequest) (*JobScalingOptions, error) {
 	if jobName == "" {
 		return nil, fmt.Errorf("jobName is required")
 	}
@@ -100,7 +100,7 @@ func (s *ServerlessJobsService) UpdateJobDeploymentScaling(ctx context.Context, 
 		return nil, fmt.Errorf("request cannot be nil")
 	}
 	path := fmt.Sprintf("/job-deployments/%s/scaling", jobName)
-	scaling, _, err := patchRequest[ContainerScalingOptions](ctx, s.client, path, req)
+	scaling, _, err := patchRequest[JobScalingOptions](ctx, s.client, path, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Missed these on the last run, these endpoints are also returning job scaling rules instead of container scaling rules.

## Type of Change


- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ✅ Test updates
