### PR TITLE
Adds container name which is needed for updating serverless containers

### DIFF
--- a/pkg/verda/container_deployments_test.go
+++ b/pkg/verda/container_deployments_test.go
@@ -283,6 +283,44 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 			t.Error("UpdateDeployment should allow partial updates without containers")
 		}
 	})
+
+	t.Run("container update - with name", func(t *testing.T) {
+		ctx := context.Background()
+		req := &UpdateDeploymentRequest{
+			Containers: []CreateDeploymentContainer{
+				{
+					Name:        "my-container",
+					Image:       "nginx:latest",
+					ExposedPort: 8080,
+				},
+			},
+		}
+		deployment, err := client.ContainerDeployments.UpdateDeployment(ctx, "test-deployment", req)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if deployment == nil {
+			t.Fatal("expected deployment, got nil")
+		}
+	})
+
+	t.Run("validation - updating container without name", func(t *testing.T) {
+		ctx := context.Background()
+		req := &UpdateDeploymentRequest{
+			Containers: []CreateDeploymentContainer{
+				{
+					Image:       "nginx:latest",
+					ExposedPort: 8080,
+					// Name is missing - API requires it for updates
+				},
+			},
+		}
+		// Should fail - API requires container name for updates
+		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "test-deployment", req)
+		if err == nil {
+			t.Error("expected error when container name is missing")
+		}
+	})
 }
 
 func TestContainerDeploymentsService_GetServerlessComputeResources(t *testing.T) {

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -493,6 +493,7 @@ type CreateDeploymentRequest struct {
 // CreateDeploymentContainer represents a container configuration for create/update requests
 // Note: In requests, image is a string; in responses, image is an object
 type CreateDeploymentContainer struct {
+	Name                string                        `json:"name,omitempty"`
 	Image               string                        `json:"image"`
 	ExposedPort         int                           `json:"exposed_port,omitempty"`
 	Healthcheck         *ContainerHealthcheck         `json:"healthcheck,omitempty"`


### PR DESCRIPTION


## Description

<!-- Provide a brief description of the changes in this PR -->

The `UpdateDeploymentRequest` type uses the `CreateDeploymentContainer` type for containers. However, the `PATCH` request to `/v1/container-deployments/{deployment_name}` API endpoint requires a container name as documented in https://api.datacrunch.io/v1/docs#tag/serverless-containers/PATCH/v1/container-deployments/{deployment_name}. 
This bug prevents update requests to be made using the SDK. 
The PR changes add a `Name` field to the `CreateDeploymentContainer` and some corresponding tests.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates

## Changes Made

<!-- List the specific changes made in this PR -->

- Updated the CreateDeploymentContainer struct to require a name field.
- Enhanced the mock server to validate the presence of the container name in update requests, returning appropriate error messages for invalid requests.
- Introduced a new test case for updating a container with a name and validation for missing container names during updates.

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] Unit tests pass locally (`make test-unit`)
- [ ] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] All CI checks pass

**Test Coverage:**
<!-- Mention if you added new tests or improved coverage -->
Added a few tests for updating server-less container deployments. 
Coverage at 58.4%.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

<!-- Link any related issues here using #issue_number -->

Closes #
Related to #

## Additional Context

<!-- Add any other context about the PR here, such as screenshots, benchmarks, etc. -->

---

**Note:** Pre-commit hooks will run automatically when you commit. Make sure to run `make check` before pushing to ensure all CI checks will pass.
