### PR TITLE
Add support for extra fields in shared filesystem volumes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Go (with security fixes)
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.12"
+          go-version: "1.24.13"
           cache: true
 
       - name: Add Go bin to PATH

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -155,7 +155,7 @@ type VolumeAttachedInstance struct {
 	IP                  *string `json:"ip"`
 	InstanceType        string  `json:"instance_type"`
 	Status              string  `json:"status"`
-	OSVolumeID          string  `json:"os_volume_id"`
+	OSVolumeID          *string `json:"os_volume_id"`
 	Hostname            string  `json:"hostname"`
 }
 

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -149,14 +149,47 @@ type Location struct {
 	Available   bool   `json:"available"`
 }
 
+type VolumeAttachedInstance struct {
+	ID                  string  `json:"id"`
+	AutoRentalExtension *bool   `json:"auto_rental_extension"`
+	IP                  *string `json:"ip"`
+	InstanceType        string  `json:"instance_type"`
+	Status              string  `json:"status"`
+	OSVolumeID          string  `json:"os_volume_id"`
+	Hostname            string  `json:"hostname"`
+}
+
+type VolumeLongTerm struct {
+	EndDate             time.Time `json:"end_date"`
+	LongTermPeriod      string    `json:"long_term_period"`
+	DiscountPercentage  int       `json:"discount_percentage"`
+	AutoRentalExtension bool      `json:"auto_rental_extension"`
+	NextPeriodPrice     float64   `json:"next_period_price"`
+	CurrentPeriodPrice  float64   `json:"current_period_price"`
+}
+
 type Volume struct {
-	ID         string    `json:"id"`
-	Name       string    `json:"name"`
-	Size       int       `json:"size"`
-	Type       string    `json:"type"`
-	Status     string    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
-	InstanceID *string   `json:"instance_id"`
+	ID                       string                   `json:"id"`
+	Name                     string                   `json:"name"`
+	Size                     int                      `json:"size"`
+	Type                     string                   `json:"type"`
+	Status                   string                   `json:"status"`
+	CreatedAt                time.Time                `json:"created_at"`
+	InstanceID               *string                  `json:"instance_id"`
+	Instances                []VolumeAttachedInstance `json:"instances"`
+	Location                 string                   `json:"location"`
+	Contract                 string                   `json:"contract,omitempty"`
+	IsOSVolume               bool                     `json:"is_os_volume"`
+	Target                   *string                  `json:"target"`
+	SSHKeyIDs                []string                 `json:"ssh_key_ids"`
+	PseudoPath               *string                  `json:"pseudo_path"`
+	CreateDirectoryCommand   *string                  `json:"create_directory_command"`
+	MountCommand             *string                  `json:"mount_command"`
+	FilesystemToFstabCommand *string                  `json:"filesystem_to_fstab_command"`
+	BaseHourlyCost           float64                  `json:"base_hourly_cost"`
+	MonthlyPrice             float64                  `json:"monthly_price"`
+	Currency                 string                   `json:"currency"`
+	LongTerm                 *VolumeLongTerm          `json:"long_term"`
 }
 
 type StartupScript struct {

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -143,17 +143,50 @@ type LocationAvailability struct {
 	Availabilities []string `json:"availabilities"`
 }
 
+// VolumeAttachedInstance represents a summary of an instance that has a volume attached
+type VolumeAttachedInstance struct {
+	ID                  string  `json:"id"`
+	AutoRentalExtension *bool   `json:"auto_rental_extension"`
+	IP                  *string `json:"ip"`
+	InstanceType        string  `json:"instance_type"`
+	Status              string  `json:"status"`
+	OSVolumeID          string  `json:"os_volume_id"`
+	Hostname            string  `json:"hostname"`
+}
+
+// VolumeLongTerm represents long-term rental details for a volume
+type VolumeLongTerm struct {
+	EndDate             time.Time `json:"end_date"`
+	LongTermPeriod      string    `json:"long_term_period"`
+	DiscountPercentage  int       `json:"discount_percentage"`
+	AutoRentalExtension bool      `json:"auto_rental_extension"`
+	NextPeriodPrice     float64   `json:"next_period_price"`
+	CurrentPeriodPrice  float64   `json:"current_period_price"`
+}
+
 // Volume represents a Verda volume
 type Volume struct {
-	ID         string    `json:"id"`
-	Name       string    `json:"name"`
-	Size       int       `json:"size"`
-	Type       string    `json:"type"`
-	Status     string    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
-	InstanceID *string   `json:"instance_id"`
-	Location   string    `json:"location"`
-	Contract   string    `json:"contract,omitempty"`
+	ID                       string                   `json:"id"`
+	Name                     string                   `json:"name"`
+	Size                     int                      `json:"size"`
+	Type                     string                   `json:"type"`
+	Status                   string                   `json:"status"`
+	CreatedAt                time.Time                `json:"created_at"`
+	InstanceID               *string                  `json:"instance_id"`
+	Instances                []VolumeAttachedInstance `json:"instances"`
+	Location                 string                   `json:"location"`
+	Contract                 string                   `json:"contract,omitempty"`
+	IsOSVolume               bool                     `json:"is_os_volume"`
+	Target                   *string                  `json:"target"`
+	SSHKeyIDs                []string                 `json:"ssh_key_ids"`
+	PseudoPath               *string                  `json:"pseudo_path"`
+	CreateDirectoryCommand   *string                  `json:"create_directory_command"`
+	MountCommand             *string                  `json:"mount_command"`
+	FilesystemToFstabCommand *string                  `json:"filesystem_to_fstab_command"`
+	BaseHourlyCost           float64                  `json:"base_hourly_cost"`
+	MonthlyPrice             float64                  `json:"monthly_price"`
+	Currency                 string                   `json:"currency"`
+	LongTerm                 *VolumeLongTerm          `json:"long_term"`
 }
 
 // VolumeType represents available volume type specifications


### PR DESCRIPTION
## Description

Shared filesystems and even normal volumes have attributes that weren't available in volume structs. This PR adds them.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ✅ Test updates

## Changes Made

- Volume object amended to include new fields for shared filesystems and contract details

