### PR TITLE
add security check for usage agent header

### DIFF
--- a/pkg/verda/client_test.go
+++ b/pkg/verda/client_test.go
@@ -59,7 +59,7 @@ func TestNewClient(t *testing.T) {
 			opts: []ClientOption{
 				WithClientID("test_id"),
 				WithClientSecret("test_secret"),
-				WithUserAgent("my-terraform/1.4.2"),
+				WithUserAgent("terraform-provider-verda/1.4.2"),
 			},
 			wantError: false,
 		},
@@ -341,14 +341,14 @@ func TestWithUserAgent(t *testing.T) {
 		client, err := NewClient(
 			WithClientID("test_id"),
 			WithClientSecret("test_secret"),
-			WithUserAgent("my-terraform/1.4.2"),
+			WithUserAgent("terraform-provider-verda/1.4.2"),
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if client.UserAgent != "my-terraform/1.4.2" {
-			t.Errorf("expected UserAgent 'my-terraform/1.4.2', got %q", client.UserAgent)
+		if client.UserAgent != "terraform-provider-verda/1.4.2" {
+			t.Errorf("expected UserAgent 'terraform-provider-verda/1.4.2', got %q", client.UserAgent)
 		}
 	})
 

--- a/pkg/verda/version.go
+++ b/pkg/verda/version.go
@@ -41,10 +41,34 @@ func DefaultUserAgent() string {
 // BuildUserAgent constructs the full User-Agent string.
 // If customUA is provided, it prepends it to the SDK's default User-Agent.
 // If customUA is empty, it returns just the SDK's default User-Agent.
+// The custom User-Agent is sanitized to remove control characters and capped at 256 characters.
 func BuildUserAgent(customUA string) string {
 	defaultUA := DefaultUserAgent()
 	if customUA == "" {
 		return defaultUA
 	}
-	return customUA + " " + defaultUA
+	sanitized := sanitizeUserAgent(customUA)
+	if sanitized == "" {
+		return defaultUA
+	}
+	return sanitized + " " + defaultUA
+}
+
+const maxUserAgentLen = 256
+
+// sanitizeUserAgent strips control characters and caps length to prevent
+// header injection, log pollution, and downstream parsing issues.
+func sanitizeUserAgent(ua string) string {
+	var b strings.Builder
+	b.Grow(len(ua))
+	for _, r := range ua {
+		if r >= 0x20 && r != 0x7F {
+			b.WriteRune(r)
+		}
+	}
+	result := strings.TrimSpace(b.String())
+	if len(result) > maxUserAgentLen {
+		result = result[:maxUserAgentLen]
+	}
+	return result
 }

--- a/pkg/verda/version_test.go
+++ b/pkg/verda/version_test.go
@@ -63,6 +63,30 @@ func TestBuildUserAgent(t *testing.T) {
 			expectedPrefix: "my-product-terraform-provider/1.4.2 terraform/1.6.5",
 			expectedSuffix: "verdacloud-sdk-go/",
 		},
+		{
+			name:           "CRLF characters are stripped",
+			customUA:       "my-app/1.0\r\nEvil-Header: injected",
+			expectedPrefix: "my-app/1.0Evil-Header: injected",
+			expectedSuffix: "verdacloud-sdk-go/",
+		},
+		{
+			name:           "null bytes and control chars are stripped",
+			customUA:       "my-app/1.0\x00\x01\x1F",
+			expectedPrefix: "my-app/1.0",
+			expectedSuffix: "verdacloud-sdk-go/",
+		},
+		{
+			name:           "only control chars returns default",
+			customUA:       "\r\n\x00",
+			expectedPrefix: "verdacloud-sdk-go/",
+			expectedSuffix: "",
+		},
+		{
+			name:           "whitespace-only returns default",
+			customUA:       "   ",
+			expectedPrefix: "verdacloud-sdk-go/",
+			expectedSuffix: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,6 +107,33 @@ func TestBuildUserAgent(t *testing.T) {
 			if !strings.Contains(result, "verdacloud-sdk-go/") {
 				t.Errorf("BuildUserAgent(%q) should always contain 'verdacloud-sdk-go/', got %q",
 					tt.customUA, result)
+			}
+		})
+	}
+}
+
+func TestSanitizeUserAgent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"clean input unchanged", "my-app/1.0", "my-app/1.0"},
+		{"strips CR LF", "a\r\nb", "ab"},
+		{"strips null byte", "a\x00b", "ab"},
+		{"strips all control chars", "\x01\x02\x1F\x7F", ""},
+		{"strips DEL char", "a\x7Fb", "ab"},
+		{"trims surrounding whitespace", "  my-app/1.0  ", "my-app/1.0"},
+		{"preserves internal spaces", "my-app/1.0 terraform/1.6", "my-app/1.0 terraform/1.6"},
+		{"caps at 256 characters", strings.Repeat("a", 300), strings.Repeat("a", 256)},
+		{"empty string stays empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeUserAgent(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeUserAgent(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Add security check for custom usage-agent header content 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test updates


## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] Unit tests pass locally (`make test-unit`)
- [x] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] All CI checks pass
