### PR TITLE
update instance requst for spot volume policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Add Go bin to PATH
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.23", "1.24"]
+        go-version: ["1.24", "1.25"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,11 +51,11 @@ jobs:
         run: make test-unit
 
       - name: Generate coverage report
-        if: matrix.go-version == '1.23'
+        if: matrix.go-version == '1.24'
         run: make coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.23'
+        if: matrix.go-version == '1.24'
         uses: codecov/codecov-action@v4
         with:
           files: ./build/coverage.out
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Build SDK
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Check formatting
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Check go mod tidy
@@ -134,10 +134,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go (with security fixes)
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25"
           cache: true
 
       - name: Add Go bin to PATH
@@ -180,7 +180,7 @@ jobs:
         if: steps.check-secrets.outputs.available == 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Run e2e tests

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Add Go bin to PATH

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  go: "1.24"
+  go: "1.25"
   concurrency: 4
   timeout: 5m
   tests: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: `Delete` and `Discontinue` add `deletePermanently bool` parameter
 - `Action` properly handles 202 (success), 204 (already in state), 207 (partial failure), 400, 404
 - Remove `omitempty` from `VolumeIDs` to distinguish nil (API default) from empty array (no volumes)
+- Bump minimum Go version to 1.25 (fixes GO-2026-4602, GO-2026-4601 stdlib vulnerabilities)
+- Update CI test matrix from Go 1.23/1.24 to Go 1.24/1.25
 
 ## [v1.2.2] - 2026-02-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add spot volume removal policy (`on_spot_discontinue`) and related constants
+- Add `delete_permanently` field to `InstanceActionRequest`
+- Add `InstanceActionResult` type for action responses and handle response code properly
+
+### Changed
+- **Breaking**: `Action` now takes `InstanceActionRequest` struct and returns `([]InstanceActionResult, error)`
+- **Breaking**: `Delete` and `Discontinue` add `deletePermanently bool` parameter
+- `Action` properly handles 202 (success), 204 (already in state), 207 (partial failure), 400, 404
+- Remove `omitempty` from `VolumeIDs` to distinguish nil (API default) from empty array (no volumes)
 
 ## [v1.2.2] - 2026-02-25
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/verda-cloud/verdacloud-sdk-go
 
-go 1.24
+go 1.25.8

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/verda-cloud/verdacloud-sdk-go
 
-go 1.25.8
+go 1.25

--- a/pkg/verda/auth.go
+++ b/pkg/verda/auth.go
@@ -70,7 +70,7 @@ func (s *AuthService) authenticateWithoutLock() (*TokenResponse, error) {
 
 // doTokenRequest tries JSON first (production), falls back to form-encoded (staging quirk)
 func (s *AuthService) doTokenRequest(body TokenRequest) (*TokenResponse, error) {
-	payload, err := json.Marshal(body)
+	payload, err := json.Marshal(body) //nolint:gosec // G117: OAuth token request must include client_secret
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal token request: %w", err)
 	}

--- a/pkg/verda/auth_test.go
+++ b/pkg/verda/auth_test.go
@@ -115,11 +115,11 @@ func TestAuthService_RefreshToken(t *testing.T) {
 
 		// Set up mock server to fail refresh but succeed authentication
 		mockServer.SetHandler(http.MethodPost, "/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
-			if err := r.ParseForm(); err != nil {
+			if err := r.ParseForm(); err != nil { //nolint:gosec // G120: test mock server
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			if r.FormValue("grant_type") == "refresh_token" {
+			if r.FormValue("grant_type") == "refresh_token" { //nolint:gosec // G120: test mock server
 				// Fail refresh
 				testutil.ErrorResponse(w, http.StatusBadRequest, "Invalid refresh token")
 				return

--- a/pkg/verda/client.go
+++ b/pkg/verda/client.go
@@ -227,7 +227,7 @@ func (c *Client) Do(req *http.Request, result any) (*Response, error) {
 		}
 	}
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.HTTPClient.Do(req) //nolint:gosec // G704: SDK client - URL is configured by caller
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/pkg/verda/instances.go
+++ b/pkg/verda/instances.go
@@ -95,15 +95,40 @@ func (s *InstanceService) createWithPlainTextResponse(ctx context.Context, req C
 	return &instance, nil
 }
 
-func (s *InstanceService) Action(ctx context.Context, ids []string, action string, volumeIDs []string) error {
-	req := InstanceActionRequest{
-		Action:    action,
-		ID:        ids,
-		VolumeIDs: volumeIDs,
+// Action performs an action on one or more instances.
+func (s *InstanceService) Action(ctx context.Context, req InstanceActionRequest) ([]InstanceActionResult, error) {
+	resp, err := s.client.makeRequest(ctx, http.MethodPut, "/instances", req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	_, _, err := putRequest[any](ctx, s.client, "/instances", req)
-	return err
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil, nil
+
+	case http.StatusAccepted, http.StatusMultiStatus:
+		var results []InstanceActionResult
+		if err := json.Unmarshal(body, &results); err != nil {
+			return nil, fmt.Errorf("failed to parse action results: %w", err)
+		}
+		return results, nil
+
+	default:
+		var apiError APIError
+		if err := json.Unmarshal(body, &apiError); err != nil {
+			return nil, &APIError{StatusCode: resp.StatusCode, Message: string(body)}
+		}
+		apiError.StatusCode = resp.StatusCode
+		return nil, &apiError
+	}
 }
 
 func (s *InstanceService) GetLocationAvailabilities(ctx context.Context) ([]LocationAvailability, error) {
@@ -158,47 +183,58 @@ func (s *InstanceService) CheckInstanceTypeAvailability(ctx context.Context, ins
 }
 
 func (s *InstanceService) Boot(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionBoot, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionBoot, ID: ids})
+	return err
 }
 
 func (s *InstanceService) Start(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionStart, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionStart, ID: ids})
+	return err
 }
 
 func (s *InstanceService) Shutdown(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionShutdown, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionShutdown, ID: ids})
+	return err
 }
 
-func (s *InstanceService) Delete(ctx context.Context, volumeIDs []string, ids ...string) error {
-	return s.Action(ctx, ids, ActionDelete, volumeIDs)
+func (s *InstanceService) Delete(ctx context.Context, ids []string, volumeIDs []string, deletePermanently bool) error {
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionDelete, ID: ids, VolumeIDs: volumeIDs, DeletePermanently: deletePermanently})
+	return err
 }
 
-func (s *InstanceService) Discontinue(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionDiscontinue, nil)
+func (s *InstanceService) Discontinue(ctx context.Context, ids []string, volumeIDs []string, deletePermanently bool) error {
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionDiscontinue, ID: ids, VolumeIDs: volumeIDs, DeletePermanently: deletePermanently})
+	return err
 }
 
 // Hibernate shuts down and archives an instance - must be shut down first or API will error.
 // Volumes are detached and the instance is deleted during hibernation.
 func (s *InstanceService) Hibernate(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionHibernate, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionHibernate, ID: ids})
+	return err
 }
 
 func (s *InstanceService) ConfigureSpot(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionConfigureSpot, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionConfigureSpot, ID: ids})
+	return err
 }
 
 func (s *InstanceService) ForceShutdown(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionForceShutdown, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionForceShutdown, ID: ids})
+	return err
 }
 
 func (s *InstanceService) DeleteStuck(ctx context.Context, volumeIDs []string, ids ...string) error {
-	return s.Action(ctx, ids, ActionDeleteStuck, volumeIDs)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionDeleteStuck, ID: ids, VolumeIDs: volumeIDs})
+	return err
 }
 
 func (s *InstanceService) Deploy(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionDeploy, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionDeploy, ID: ids})
+	return err
 }
 
 func (s *InstanceService) Transfer(ctx context.Context, ids ...string) error {
-	return s.Action(ctx, ids, ActionTransfer, nil)
+	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionTransfer, ID: ids})
+	return err
 }

--- a/pkg/verda/instances_test.go
+++ b/pkg/verda/instances_test.go
@@ -2,6 +2,10 @@ package verda
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
 	"testing"
 
 	"github.com/verda-cloud/verdacloud-sdk-go/pkg/verda/testutil"
@@ -136,7 +140,7 @@ func TestInstanceService_Create(t *testing.T) {
 				{Size: 500, Type: VolumeTypeNVMe, Name: "data"},
 			},
 			ExistingVolumes: []string{"vol_123"},
-			OSVolume:        &OSVolumeCreateRequest{Size: 100},
+			OSVolume:        &OSVolumeCreateRequest{Size: 100, Name: "os-vol"},
 			IsSpot:          true,
 			Coupon:          stringPtr("DISCOUNT20"),
 		}
@@ -161,35 +165,317 @@ func TestInstanceService_Create(t *testing.T) {
 	})
 }
 
+func TestInstanceService_CreateSpotWithDiscontinuePolicy(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	client := NewTestClient(mockServer)
+
+	t.Run("create spot instance with on_spot_discontinue on os_volume", func(t *testing.T) {
+		req := CreateInstanceRequest{
+			InstanceType: "CPU.4V.16G",
+			Image:        "ubuntu-24.04",
+			Hostname:     "test-spot-instance",
+			SSHKeyIDs:    []string{"key_123"},
+			LocationCode: "FIN-03",
+			IsSpot:       true,
+			OSVolume: &OSVolumeCreateRequest{
+				Name:              "test-os-volume",
+				Size:              55,
+				OnSpotDiscontinue: SpotDiscontinueDeletePermanent,
+			},
+		}
+
+		ctx := context.Background()
+		instance, err := client.Instances.Create(ctx, req)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if instance == nil {
+			t.Fatal("expected instance, got nil")
+		}
+	})
+
+	t.Run("create spot instance with on_spot_discontinue on additional volumes", func(t *testing.T) {
+		req := CreateInstanceRequest{
+			InstanceType: "CPU.4V.16G",
+			Image:        "ubuntu-24.04",
+			Hostname:     "test-spot-volumes",
+			SSHKeyIDs:    []string{"key_123"},
+			LocationCode: "FIN-03",
+			IsSpot:       true,
+			OSVolume: &OSVolumeCreateRequest{
+				Name:              "test-os-volume",
+				Size:              55,
+				OnSpotDiscontinue: SpotDiscontinueKeepDetached,
+			},
+			Volumes: []VolumeCreateRequest{
+				{
+					Size:              500,
+					Type:              VolumeTypeNVMe,
+					Name:              "data-vol",
+					OnSpotDiscontinue: SpotDiscontinueMoveToTrash,
+				},
+			},
+		}
+
+		ctx := context.Background()
+		instance, err := client.Instances.Create(ctx, req)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if instance == nil {
+			t.Fatal("expected instance, got nil")
+		}
+	})
+}
+
 func TestInstanceService_Action(t *testing.T) {
 	mockServer := testutil.NewMockServer()
 	defer mockServer.Close()
 
 	client := NewTestClient(mockServer)
 
-	t.Run("action on instance", func(t *testing.T) {
+	t.Run("202 single instance returns results", func(t *testing.T) {
 		ctx := context.Background()
-		err := client.Instances.Action(ctx, []string{"inst_123"}, ActionShutdown, nil)
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action: ActionShutdown,
+			ID:     []string{"inst_123"},
+		})
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].InstanceID != "inst_123" {
+			t.Errorf("expected instanceId 'inst_123', got '%s'", results[0].InstanceID)
+		}
+		if results[0].Status != "success" {
+			t.Errorf("expected status 'success', got '%s'", results[0].Status)
 		}
 	})
 
-	t.Run("action on multiple instances", func(t *testing.T) {
+	t.Run("202 multiple instances returns results", func(t *testing.T) {
 		ctx := context.Background()
-		err := client.Instances.Action(ctx, []string{"inst_123", "inst_456"}, ActionShutdown, nil)
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action: ActionShutdown,
+			ID:     []string{"inst_123", "inst_456"},
+		})
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
 		}
 	})
 
 	t.Run("action delete with volumes", func(t *testing.T) {
 		ctx := context.Background()
-		err := client.Instances.Action(ctx, []string{"inst_123"}, ActionDelete, []string{"vol_123"})
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action:    ActionDelete,
+			ID:        []string{"inst_123"},
+			VolumeIDs: []string{"vol_123"},
+		})
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
 		}
 	})
+
+	t.Run("action delete with empty volume_ids (no volumes deleted)", func(t *testing.T) {
+		ctx := context.Background()
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action:    ActionDelete,
+			ID:        []string{"inst_123"},
+			VolumeIDs: []string{},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("action delete with nil volume_ids (API default)", func(t *testing.T) {
+		ctx := context.Background()
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action: ActionDelete,
+			ID:     []string{"inst_123"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("action delete with volumes permanently", func(t *testing.T) {
+		ctx := context.Background()
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action:            ActionDelete,
+			ID:                []string{"inst_123"},
+			VolumeIDs:         []string{"vol_123"},
+			DeletePermanently: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("action discontinue with volumes permanently", func(t *testing.T) {
+		ctx := context.Background()
+		results, err := client.Instances.Action(ctx, InstanceActionRequest{
+			Action:            ActionDiscontinue,
+			ID:                []string{"inst_123"},
+			VolumeIDs:         []string{"vol_123"},
+			DeletePermanently: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+}
+
+func TestInstanceService_Action_204_AlreadyInState(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	mockServer.SetHandler("PUT", "/instances", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := NewTestClient(mockServer)
+	ctx := context.Background()
+
+	results, err := client.Instances.Action(ctx, InstanceActionRequest{
+		Action: ActionBoot,
+		ID:     []string{"inst_123"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for 204: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil results for 204, got %v", results)
+	}
+}
+
+func TestInstanceService_Action_207_PartialFailure(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	mockServer.SetHandler("PUT", "/instances", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMultiStatus)
+		writeTestJSON(w, []map[string]interface{}{
+			{"action": "shutdown", "instanceId": "inst_123", "status": "success"},
+			{"action": "shutdown", "instanceId": "inst_456", "status": "error", "error": "instance not found", "statusCode": 404},
+		})
+	})
+
+	client := NewTestClient(mockServer)
+	ctx := context.Background()
+
+	results, err := client.Instances.Action(ctx, InstanceActionRequest{
+		Action: ActionShutdown,
+		ID:     []string{"inst_123", "inst_456"},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error for 207: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Status != "success" {
+		t.Errorf("expected first result success, got %s", results[0].Status)
+	}
+	if results[1].Status != "error" {
+		t.Errorf("expected second result error, got %s", results[1].Status)
+	}
+	if results[1].Error != "instance not found" {
+		t.Errorf("expected error message 'instance not found', got '%s'", results[1].Error)
+	}
+	if results[1].StatusCode != 404 {
+		t.Errorf("expected status code 404, got %d", results[1].StatusCode)
+	}
+}
+
+func TestInstanceService_Action_400_BadRequest(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	mockServer.SetHandler("PUT", "/instances", func(w http.ResponseWriter, _ *http.Request) {
+		testutil.ErrorResponse(w, http.StatusBadRequest, "action not allowed in current state")
+	})
+
+	client := NewTestClient(mockServer)
+	ctx := context.Background()
+
+	results, err := client.Instances.Action(ctx, InstanceActionRequest{
+		Action: ActionBoot,
+		ID:     []string{"inst_123"},
+	})
+
+	if err == nil {
+		t.Fatal("expected error for 400, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", apiErr.StatusCode)
+	}
+
+	if results != nil {
+		t.Errorf("expected nil results for 400, got %v", results)
+	}
+}
+
+func TestInstanceService_Action_404_NotFound(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	mockServer.SetHandler("PUT", "/instances", func(w http.ResponseWriter, _ *http.Request) {
+		testutil.ErrorResponse(w, http.StatusNotFound, "instance not found")
+	})
+
+	client := NewTestClient(mockServer)
+	ctx := context.Background()
+
+	results, err := client.Instances.Action(ctx, InstanceActionRequest{
+		Action: ActionDelete,
+		ID:     []string{"inst_nonexistent"},
+	})
+
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", apiErr.StatusCode)
+	}
+
+	if results != nil {
+		t.Errorf("expected nil results for 404, got %v", results)
+	}
 }
 
 func TestInstanceService_ConvenienceMethods(t *testing.T) {
@@ -224,15 +510,15 @@ func TestInstanceService_ConvenienceMethods(t *testing.T) {
 
 	t.Run("delete instance", func(t *testing.T) {
 		ctx := context.Background()
-		err := client.Instances.Delete(ctx, []string{"vol_123"}, "inst_123")
+		err := client.Instances.Delete(ctx, []string{"inst_123"}, []string{"vol_123"}, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("delete multiple instances", func(t *testing.T) {
+	t.Run("delete instance permanently", func(t *testing.T) {
 		ctx := context.Background()
-		err := client.Instances.Delete(ctx, []string{"vol_123"}, "inst_123", "inst_456")
+		err := client.Instances.Delete(ctx, []string{"inst_123"}, []string{"vol_123"}, true)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -240,7 +526,15 @@ func TestInstanceService_ConvenienceMethods(t *testing.T) {
 
 	t.Run("discontinue instance", func(t *testing.T) {
 		ctx := context.Background()
-		err := client.Instances.Discontinue(ctx, "inst_123")
+		err := client.Instances.Discontinue(ctx, []string{"inst_123"}, nil, false)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("discontinue instance with volumes permanently", func(t *testing.T) {
+		ctx := context.Background()
+		err := client.Instances.Discontinue(ctx, []string{"inst_123"}, []string{"vol_123"}, true)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -278,14 +572,6 @@ func TestInstanceService_ConvenienceMethods(t *testing.T) {
 		}
 	})
 
-	t.Run("delete stuck multiple instances", func(t *testing.T) {
-		ctx := context.Background()
-		err := client.Instances.DeleteStuck(ctx, []string{"vol_123"}, "inst_123", "inst_456")
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
 	t.Run("deploy instance", func(t *testing.T) {
 		ctx := context.Background()
 		err := client.Instances.Deploy(ctx, "inst_123")
@@ -303,7 +589,12 @@ func TestInstanceService_ConvenienceMethods(t *testing.T) {
 	})
 }
 
-// Helper function for string pointers
+func writeTestJSON(w http.ResponseWriter, v interface{}) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("test: failed to encode JSON: %v", err)
+	}
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -590,13 +590,13 @@ func (ms *MockServer) handleAuth(w http.ResponseWriter, r *http.Request) {
 		clientSecret = tokenReq.ClientSecret
 	} else {
 		// Parse form data
-		if err := r.ParseForm(); err != nil {
+		if err := r.ParseForm(); err != nil { //nolint:gosec // G120: test mock server, not production
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		grantType = r.FormValue("grant_type")
-		clientID = r.FormValue("client_id")
-		clientSecret = r.FormValue("client_secret")
+		grantType = r.FormValue("grant_type")       //nolint:gosec // G120: test mock server
+		clientID = r.FormValue("client_id")         //nolint:gosec // G120: test mock server
+		clientSecret = r.FormValue("client_secret") //nolint:gosec // G120: test mock server
 	}
 
 	if grantType == "" || clientID == "" || clientSecret == "" {
@@ -625,7 +625,7 @@ func (ms *MockServer) handleGetInstances(w http.ResponseWriter, _ *http.Request)
 	osVolumeID := "vol_os_123"
 
 	instances := []Instance{
-		{
+		{ //nolint:gosec // G101: test fixture, not real credentials
 			ID:              "inst_123",
 			IP:              &ip,
 			Status:          StatusRunning,
@@ -672,7 +672,7 @@ func (ms *MockServer) handleGetInstance(w http.ResponseWriter, r *http.Request) 
 	scriptID := "script_123"
 	osVolumeID := "vol_os_123"
 
-	instance := Instance{
+	instance := Instance{ //nolint:gosec // G101: test fixture, not real credentials
 		ID:              instanceID,
 		IP:              &ip,
 		Status:          StatusRunning,
@@ -731,7 +731,7 @@ func (ms *MockServer) handleCreateInstance(w http.ResponseWriter, r *http.Reques
 	ip := mockIPAddress
 	osVolumeID := "vol_os_new_123"
 
-	instance := Instance{
+	instance := Instance{ //nolint:gosec // G101: test fixture, not real credentials
 		ID:              "inst_new_123",
 		IP:              &ip,
 		Status:          StatusPending,

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -769,8 +769,24 @@ func (ms *MockServer) handleInstanceAction(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Mock successful action - API returns 202 Accepted with empty body
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
+
+	type actionResult struct {
+		Action     string `json:"action"`
+		InstanceID string `json:"instanceId"`
+		Status     string `json:"status"`
+	}
+
+	var results []actionResult
+	for _, id := range req.ID {
+		results = append(results, actionResult{
+			Action:     req.Action,
+			InstanceID: id,
+			Status:     "success",
+		})
+	}
+	writeJSON(w, results)
 }
 
 func (ms *MockServer) handleGetBalance(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -77,10 +77,11 @@ type CreateInstanceRequest struct {
 
 // VolumeCreateRequest represents a volume to be created
 type VolumeCreateRequest struct {
-	Size         int    `json:"size"`
-	Type         string `json:"type"`
-	Name         string `json:"name"`
-	LocationCode string `json:"location_code,omitempty"`
+	Size              int    `json:"size"`
+	Type              string `json:"type"`
+	Name              string `json:"name"`
+	LocationCode      string `json:"location_code,omitempty"`
+	OnSpotDiscontinue string `json:"on_spot_discontinue,omitempty"`
 }
 
 // VolumeAttachRequest represents a request to attach a volume to an instance
@@ -120,15 +121,29 @@ type VolumeRenameRequest struct {
 
 // OSVolumeCreateRequest represents OS volume configuration
 type OSVolumeCreateRequest struct {
-	Name string `json:"name"`
-	Size int    `json:"size"`
+	Name              string `json:"name"`
+	Size              int    `json:"size"`
+	OnSpotDiscontinue string `json:"on_spot_discontinue,omitempty"`
 }
 
-// InstanceActionRequest represents an action to perform on instances
+// InstanceActionRequest represents an action to perform on instances.
+// VolumeIDs: nil omits the field (API default: OS volume deleted, rest detached),
+// empty slice sends [] (no volumes deleted), slice with IDs deletes those volumes.
 type InstanceActionRequest struct {
-	Action    string   `json:"action"`
-	ID        []string `json:"id"`
-	VolumeIDs []string `json:"volume_ids,omitempty"`
+	Action            string   `json:"action"`
+	ID                []string `json:"id"`
+	VolumeIDs         []string `json:"volume_ids"`
+	DeletePermanently bool     `json:"delete_permanently,omitempty"`
+}
+
+// InstanceActionResult represents the per-instance outcome of an action request.
+// Returned as an array for 202 (all succeeded) and 207 (some failed) responses.
+type InstanceActionResult struct {
+	Action     string `json:"action"`
+	InstanceID string `json:"instanceId"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+	StatusCode int    `json:"statusCode,omitempty"`
 }
 
 // InstanceAvailability represents instance availability information
@@ -321,7 +336,6 @@ const (
 )
 
 // Instance status constants
-// Instance status constants
 const (
 	StatusNew          = "new"
 	StatusOrdered      = "ordered"
@@ -341,6 +355,13 @@ const (
 // Default location (used when no location is specified)
 const (
 	LocationFIN01 = "FIN-01"
+)
+
+// Spot discontinue policy constants for volume behavior when a spot instance is discontinued
+const (
+	SpotDiscontinueKeepDetached    = "keep_detached"
+	SpotDiscontinueMoveToTrash     = "move_to_trash"
+	SpotDiscontinueDeletePermanent = "delete_permanently"
 )
 
 // Volume type constants


### PR DESCRIPTION
- Add spot volume removal policy (`on_spot_discontinue`) and related constants
- Add `delete_permanently` field to `InstanceActionRequest`
- Add `InstanceActionResult` type for action responses and handle response code properly

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates

## Changes Made

<!-- List the specific changes made in this PR -->
Support new spot volume policy
- Add spot volume removal policy (`on_spot_discontinue`) and related constants
- Add `delete_permanently` field to `InstanceActionRequest`
- Add `InstanceActionResult` type for action responses and handle response code properly

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] Unit tests pass locally (`make test-unit`)
- [x] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] All CI checks pass

