### PR TITLE
container deployments openapi sync

### DIFF
--- a/pkg/verda/container_deployments.go
+++ b/pkg/verda/container_deployments.go
@@ -10,6 +10,55 @@ type ContainerDeploymentsService struct {
 	client *Client
 }
 
+func validateUpdateDeploymentRequest(req *UpdateDeploymentRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+
+	if req.Scaling != nil {
+		return fmt.Errorf("deployment scaling updates must use UpdateDeploymentScaling")
+	}
+
+	for i, container := range req.Containers {
+		if container.Name == "" {
+			return fmt.Errorf("containers[%d].name is required", i)
+		}
+		if container.Image != "" && isLatestTag(container.Image) {
+			return fmt.Errorf("containers[%d].image: 'latest' tag is not allowed, please specify a specific version tag (e.g., nginx:1.25.3)", i)
+		}
+	}
+
+	return nil
+}
+
+func validateContainerEnvironmentVariablesRequest(req *ContainerEnvVarsRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ContainerName == "" {
+		return fmt.Errorf("container_name is required")
+	}
+	if len(req.Env) == 0 {
+		return fmt.Errorf("env array cannot be empty")
+	}
+
+	return nil
+}
+
+func validateDeleteContainerEnvironmentVariablesRequest(req *DeleteContainerEnvVarsRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ContainerName == "" {
+		return fmt.Errorf("container_name is required")
+	}
+	if len(req.Env) == 0 {
+		return fmt.Errorf("env array cannot be empty")
+	}
+
+	return nil
+}
+
 // GetDeployments retrieves all container deployments
 // projectID is optional - if empty, uses default project
 func (s *ContainerDeploymentsService) GetDeployments(ctx context.Context) ([]ContainerDeployment, error) {
@@ -116,15 +165,12 @@ func (s *ContainerDeploymentsService) GetDeploymentByName(ctx context.Context, d
 }
 
 func (s *ContainerDeploymentsService) UpdateDeployment(ctx context.Context, deploymentName string, req *UpdateDeploymentRequest) (*ContainerDeployment, error) {
-	// Validate required fields for update
-	if req == nil {
-		return nil, fmt.Errorf("request cannot be nil")
-	}
 	if deploymentName == "" {
 		return nil, fmt.Errorf("deploymentName is required")
 	}
-	// Note: UpdateDeployment is a PATCH operation, so partial updates are allowed.
-	// Containers are optional - you can update just scaling, compute, or other fields.
+	if err := validateUpdateDeploymentRequest(req); err != nil {
+		return nil, err
+	}
 
 	path := fmt.Sprintf("/container-deployments/%s", deploymentName)
 	deployment, _, err := patchRequest[ContainerDeployment](ctx, s.client, path, req)
@@ -236,70 +282,64 @@ func (s *ContainerDeploymentsService) GetDeploymentReplicas(ctx context.Context,
 	return &replicas, nil
 }
 
-func (s *ContainerDeploymentsService) GetEnvironmentVariables(ctx context.Context, deploymentName string) ([]ContainerEnvVar, error) {
+func (s *ContainerDeploymentsService) GetEnvironmentVariables(ctx context.Context, deploymentName string) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
 		return nil, fmt.Errorf("deploymentName is required")
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	envVars, _, err := getRequest[[]ContainerEnvVar](ctx, s.client, path)
+	envVars, _, err := getRequest[[]DeploymentEnvironmentVariables](ctx, s.client, path)
 	if err != nil {
 		return nil, err
 	}
 	return envVars, nil
 }
 
-func (s *ContainerDeploymentsService) AddEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) error {
+func (s *ContainerDeploymentsService) AddEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
-		return fmt.Errorf("deploymentName is required")
+		return nil, fmt.Errorf("deploymentName is required")
 	}
-	if req == nil {
-		return fmt.Errorf("request cannot be nil")
-	}
-	if req.ContainerName == "" {
-		return fmt.Errorf("container_name is required")
-	}
-	if len(req.Env) == 0 {
-		return fmt.Errorf("env array cannot be empty")
+	if err := validateContainerEnvironmentVariablesRequest(req); err != nil {
+		return nil, err
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	_, _, err := postRequest[interface{}](ctx, s.client, path, req)
-	return err
+	envVars, _, err := postRequest[[]DeploymentEnvironmentVariables](ctx, s.client, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVars, nil
 }
 
-func (s *ContainerDeploymentsService) UpdateEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) error {
+func (s *ContainerDeploymentsService) UpdateEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
-		return fmt.Errorf("deploymentName is required")
+		return nil, fmt.Errorf("deploymentName is required")
 	}
-	if req == nil {
-		return fmt.Errorf("request cannot be nil")
-	}
-	if req.ContainerName == "" {
-		return fmt.Errorf("container_name is required")
-	}
-	if len(req.Env) == 0 {
-		return fmt.Errorf("env array cannot be empty")
+	if err := validateContainerEnvironmentVariablesRequest(req); err != nil {
+		return nil, err
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	_, _, err := patchRequest[interface{}](ctx, s.client, path, req)
-	return err
+	envVars, _, err := patchRequest[[]DeploymentEnvironmentVariables](ctx, s.client, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVars, nil
 }
 
-func (s *ContainerDeploymentsService) DeleteEnvironmentVariables(ctx context.Context, deploymentName string, req *DeleteContainerEnvVarsRequest) error {
+func (s *ContainerDeploymentsService) DeleteEnvironmentVariables(ctx context.Context, deploymentName string, req *DeleteContainerEnvVarsRequest) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
-		return fmt.Errorf("deploymentName is required")
+		return nil, fmt.Errorf("deploymentName is required")
 	}
-	if req == nil {
-		return fmt.Errorf("request cannot be nil")
-	}
-	if req.ContainerName == "" {
-		return fmt.Errorf("container_name is required")
-	}
-	if len(req.Env) == 0 {
-		return fmt.Errorf("env array cannot be empty")
+	if err := validateDeleteContainerEnvironmentVariablesRequest(req); err != nil {
+		return nil, err
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	_, err := deleteRequestWithBody(ctx, s.client, path, req)
-	return err
+	envVars, _, err := requestWithBody[[]DeploymentEnvironmentVariables](ctx, s.client, "DELETE", path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVars, nil
 }
 
 func (s *ContainerDeploymentsService) GetServerlessComputeResources(ctx context.Context) ([]ComputeResource, error) {

--- a/pkg/verda/container_deployments_test.go
+++ b/pkg/verda/container_deployments_test.go
@@ -256,10 +256,10 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 
 	t.Run("validation - empty deployment name", func(t *testing.T) {
 		ctx := context.Background()
-		maxReplicas := 2
 		req := &UpdateDeploymentRequest{
-			Scaling: &ContainerScalingOptions{
-				MaxReplicaCount: maxReplicas,
+			Compute: &ContainerCompute{
+				Name: "H100",
+				Size: 1,
 			},
 		}
 		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "", req)
@@ -268,19 +268,19 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("partial update - scaling only", func(t *testing.T) {
+	t.Run("validation - scaling updates must use dedicated endpoint", func(t *testing.T) {
 		ctx := context.Background()
-		maxReplicas := 3
 		req := &UpdateDeploymentRequest{
 			Scaling: &ContainerScalingOptions{
-				MaxReplicaCount: maxReplicas,
+				MaxReplicaCount: 3,
 			},
 		}
-		// This should not fail validation - partial updates are allowed
 		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "test-deployment", req)
-		// The mock server may return an error, but validation should pass
-		if err != nil && err.Error() == "at least one container is required" {
-			t.Error("UpdateDeployment should allow partial updates without containers")
+		if err == nil {
+			t.Fatal("expected error for scaling update on deployment patch")
+		}
+		if err.Error() != "deployment scaling updates must use UpdateDeploymentScaling" {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -290,7 +290,7 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 			Containers: []CreateDeploymentContainer{
 				{
 					Name:        "my-container",
-					Image:       "nginx:latest",
+					Image:       "nginx:1.25.3",
 					ExposedPort: 8080,
 				},
 			},
@@ -309,16 +309,100 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 		req := &UpdateDeploymentRequest{
 			Containers: []CreateDeploymentContainer{
 				{
-					Image:       "nginx:latest",
+					Image:       "nginx:1.25.3",
 					ExposedPort: 8080,
 					// Name is missing - API requires it for updates
 				},
 			},
 		}
-		// Should fail - API requires container name for updates
 		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "test-deployment", req)
 		if err == nil {
 			t.Error("expected error when container name is missing")
+		}
+	})
+}
+
+func TestContainerDeploymentsService_EnvironmentVariables(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	client := NewTestClient(mockServer)
+
+	t.Run("get environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.GetEnvironmentVariables(ctx, "flux")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 {
+			t.Fatalf("expected 1 environment variable set, got %d", len(envSets))
+		}
+		if envSets[0].ContainerName != "flux-0" {
+			t.Fatalf("expected container name flux-0, got %s", envSets[0].ContainerName)
+		}
+		if len(envSets[0].Env) != 1 {
+			t.Fatalf("expected 1 environment variable, got %d", len(envSets[0].Env))
+		}
+		if envSets[0].Env[0].Name != "MY_ENV_VAR" {
+			t.Fatalf("expected environment variable MY_ENV_VAR, got %s", envSets[0].Env[0].Name)
+		}
+	})
+
+	t.Run("add environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.AddEnvironmentVariables(ctx, "flux", &ContainerEnvVarsRequest{
+			ContainerName: "flux-0",
+			Env: []ContainerEnvVar{
+				{
+					Name:                     "NEW_ENV_VAR",
+					ValueOrReferenceToSecret: "new-value",
+					Type:                     "plain",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 || len(envSets[0].Env) != 2 {
+			t.Fatalf("expected added environment variables to be returned, got %+v", envSets)
+		}
+	})
+
+	t.Run("update environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.UpdateEnvironmentVariables(ctx, "flux", &ContainerEnvVarsRequest{
+			ContainerName: "flux-0",
+			Env: []ContainerEnvVar{
+				{
+					Name:                     "MY_ENV_VAR",
+					ValueOrReferenceToSecret: "updated-value",
+					Type:                     "plain",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 || envSets[0].Env[0].ValueOrReferenceToSecret != "updated-value" {
+			t.Fatalf("expected updated environment variables to be returned, got %+v", envSets)
+		}
+	})
+
+	t.Run("delete environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.DeleteEnvironmentVariables(ctx, "flux", &DeleteContainerEnvVarsRequest{
+			ContainerName: "flux-0",
+			Env:           []string{"MY_ENV_VAR"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 || len(envSets[0].Env) != 0 {
+			t.Fatalf("expected empty environment variable set after delete, got %+v", envSets)
 		}
 	})
 }

--- a/pkg/verda/serverless_jobs.go
+++ b/pkg/verda/serverless_jobs.go
@@ -87,6 +87,22 @@ func (s *ServerlessJobsService) GetJobDeploymentByName(ctx context.Context, jobN
 	return &job, nil
 }
 
+func (s *ServerlessJobsService) UpdateJobDeployment(ctx context.Context, jobName string, req *UpdateJobDeploymentRequest) (*JobDeployment, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request cannot be nil")
+	}
+	if jobName == "" {
+		return nil, fmt.Errorf("jobName is required")
+	}
+	// UpdateJobDeployment is a PATCH operation, so partial updates are allowed.
+	path := fmt.Sprintf("/job-deployments/%s", jobName)
+	job, _, err := patchRequest[JobDeployment](ctx, s.client, path, req)
+	if err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
 // DeleteJobDeployment removes a job with timeout in milliseconds (0-300000ms)
 // timeoutMs behavior:
 //   - 0: Skip waiting (returns immediately)

--- a/pkg/verda/serverless_jobs_test.go
+++ b/pkg/verda/serverless_jobs_test.go
@@ -171,6 +171,90 @@ func TestServerlessJobsService_GetJobDeploymentByName(t *testing.T) {
 	})
 }
 
+func TestServerlessJobsService_UpdateJobDeployment(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	client := NewTestClient(mockServer)
+
+	t.Run("validation - nil request", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := client.ServerlessJobs.UpdateJobDeployment(ctx, "test-job", nil)
+		if err == nil {
+			t.Error("expected error for nil request")
+		}
+	})
+
+	t.Run("validation - empty job name", func(t *testing.T) {
+		ctx := context.Background()
+		req := &UpdateJobDeploymentRequest{
+			Scaling: &JobScalingOptions{
+				MaxReplicaCount:        2,
+				QueueMessageTTLSeconds: 300,
+				DeadlineSeconds:        3600,
+			},
+		}
+		_, err := client.ServerlessJobs.UpdateJobDeployment(ctx, "", req)
+		if err == nil {
+			t.Error("expected error for empty job name")
+		}
+	})
+
+	t.Run("partial update - scaling only", func(t *testing.T) {
+		ctx := context.Background()
+		req := &UpdateJobDeploymentRequest{
+			Scaling: &JobScalingOptions{
+				MaxReplicaCount:        2,
+				QueueMessageTTLSeconds: 300,
+				DeadlineSeconds:        3600,
+			},
+		}
+		job, err := client.ServerlessJobs.UpdateJobDeployment(ctx, "test-job", req)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if job == nil {
+			t.Fatal("expected job, got nil")
+		}
+	})
+
+	t.Run("container update - with name", func(t *testing.T) {
+		ctx := context.Background()
+		req := &UpdateJobDeploymentRequest{
+			Containers: []CreateDeploymentContainer{
+				{
+					Name:        "random-logger-0",
+					Image:       "registry-1.docker.io/chentex/random-logger:v1.0.1",
+					ExposedPort: 8080,
+				},
+			},
+		}
+		job, err := client.ServerlessJobs.UpdateJobDeployment(ctx, "test-job", req)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if job == nil {
+			t.Fatal("expected job, got nil")
+		}
+	})
+
+	t.Run("validation - updating container without name", func(t *testing.T) {
+		ctx := context.Background()
+		req := &UpdateJobDeploymentRequest{
+			Containers: []CreateDeploymentContainer{
+				{
+					Image:       "registry-1.docker.io/chentex/random-logger:v1.0.1",
+					ExposedPort: 8080,
+				},
+			},
+		}
+		_, err := client.ServerlessJobs.UpdateJobDeployment(ctx, "test-job", req)
+		if err == nil {
+			t.Error("expected error when container name is missing")
+		}
+	})
+}
+
 func TestServerlessJobsService_DeleteJobDeployment(t *testing.T) {
 	mockServer := testutil.NewMockServer()
 	defer mockServer.Close()

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -532,6 +532,8 @@ func (ms *MockServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		ms.handleGetDeploymentScaling(w, r)
 	case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/scaling") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
 		ms.handleUpdateDeploymentScaling(w, r)
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/environment-variables") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
+		ms.handleGetEnvironmentVariables(w, r)
 	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/environment-variables") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
 		ms.handleAddEnvironmentVariables(w, r)
 	case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/environment-variables") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
@@ -1720,6 +1722,12 @@ func (ms *MockServer) handleUpdateContainerDeployment(w http.ResponseWriter, r *
 		return
 	}
 
+	if _, hasScaling := req["scaling"]; hasScaling {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"message": "deployment scaling updates must use /container-deployments/{deployment_name}/scaling"})
+		return
+	}
+
 	// Validate containers have required name field (like the real API)
 	if containers, ok := req["containers"].([]interface{}); ok && len(containers) > 0 {
 		for i, c := range containers {
@@ -1780,48 +1788,67 @@ func (ms *MockServer) handleUpdateDeploymentScaling(w http.ResponseWriter, _ *ht
 	writeBytes(w, []byte(mockScalingOptionsResponse))
 }
 
+func (ms *MockServer) handleGetEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": [
+				{
+					"name": "MY_ENV_VAR",
+					"value_or_reference_to_secret": "my-value",
+					"type": "plain"
+				}
+			]
+		}
+	]`))
+}
+
 func (ms *MockServer) handleAddEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-
-	// Sample request:
-	// {
-	//   "container_name": "flux-0",
-	//   "env": [
-	//     {
-	//       "name": "MY_ENV_VAR",
-	//       "value_or_reference_to_secret": "my-value",
-	//       "type": "plain"
-	//     }
-	//   ]
-	// }
-
-	// Returns success with no body or empty object
-	writeBytes(w, []byte(`{}`))
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": [
+				{
+					"name": "MY_ENV_VAR",
+					"value_or_reference_to_secret": "my-value",
+					"type": "plain"
+				},
+				{
+					"name": "NEW_ENV_VAR",
+					"value_or_reference_to_secret": "new-value",
+					"type": "plain"
+				}
+			]
+		}
+	]`))
 }
 
 func (ms *MockServer) handleUpdateEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-
-	// Sample request:
-	// {
-	//   "container_name": "flux-0",
-	//   "env": [
-	//     {
-	//       "name": "MY_ENV_VAR",
-	//       "value_or_reference_to_secret": "my-value",
-	//       "type": "plain"
-	//     }
-	//   ]
-	// }
-
-	// Returns success with no body or empty object
-	writeBytes(w, []byte(`{}`))
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": [
+				{
+					"name": "MY_ENV_VAR",
+					"value_or_reference_to_secret": "updated-value",
+					"type": "plain"
+				}
+			]
+		}
+	]`))
 }
 
 func (ms *MockServer) handleDeleteEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNoContent)
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": []
+		}
+	]`))
 }
 
 func (ms *MockServer) handleGetServerlessComputeResources(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -557,6 +557,8 @@ func (ms *MockServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		ms.handleGetJobDeployments(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/job-deployments":
 		ms.handleCreateJobDeployment(w, r)
+	case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/job-deployments/"):
+		ms.handleUpdateJobDeployment(w, r)
 	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/scaling") && strings.HasPrefix(r.URL.Path, "/job-deployments/"):
 		ms.handleGetJobDeploymentScaling(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/job-deployments/"):
@@ -2123,6 +2125,66 @@ func (ms *MockServer) handleCreateJobDeployment(w http.ResponseWriter, r *http.R
 		"queue_message_ttl_seconds": 300,
 		"deadline_seconds": 600
 	}
+	}`
+
+	writeBytes(w, []byte(response))
+}
+
+func (ms *MockServer) handleUpdateJobDeployment(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	if containers, ok := req["containers"].([]interface{}); ok && len(containers) > 0 {
+		for i, c := range containers {
+			container, ok := c.(map[string]interface{})
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]string{"error": "invalid container format"})
+				return
+			}
+			name, hasName := container["name"]
+			if !hasName || name == nil || name == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]interface{}{
+					"message": "containers." + string(rune('0'+i)) + ".name should not be null or undefined",
+				})
+				return
+			}
+		}
+	}
+
+	response := `{
+		"name": "test-job",
+		"containers": [
+			{
+				"name": "updated-job-container",
+				"image": {
+					"image": "registry-1.docker.io/chentex/random-logger:v1.0.1",
+					"last_updated_at": "2025-11-26T16:37:50.932Z"
+				},
+				"exposed_port": 8080
+			}
+		],
+		"endpoint_base_url": "https://containers.datacrunch.io/test-job",
+		"created_at": "2021-08-31T12:00:00.000Z",
+		"compute": {
+			"name": "H100",
+			"size": 1
+		},
+		"container_registry_settings": {
+			"is_private": false
+		},
+		"scaling": {
+			"max_replica_count": 2,
+			"queue_message_ttl_seconds": 300,
+			"deadline_seconds": 3600
+		}
 	}`
 
 	writeBytes(w, []byte(response))

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -599,11 +599,12 @@ type CreateDeploymentContainer struct {
 
 // UpdateDeploymentRequest represents a request to update a deployment
 type UpdateDeploymentRequest struct {
-	IsSpot                    *bool                       `json:"is_spot,omitempty"`
-	Compute                   *ContainerCompute           `json:"compute,omitempty"`
-	ContainerRegistrySettings *ContainerRegistrySettings  `json:"container_registry_settings,omitempty"`
-	Scaling                   *ContainerScalingOptions    `json:"scaling,omitempty"`
-	Containers                []CreateDeploymentContainer `json:"containers,omitempty"`
+	IsSpot                    *bool                      `json:"is_spot,omitempty"`
+	Compute                   *ContainerCompute          `json:"compute,omitempty"`
+	ContainerRegistrySettings *ContainerRegistrySettings `json:"container_registry_settings,omitempty"`
+	// Deprecated: use UpdateDeploymentScaling with /container-deployments/{name}/scaling.
+	Scaling    *ContainerScalingOptions    `json:"-"`
+	Containers []CreateDeploymentContainer `json:"containers,omitempty"`
 }
 
 // ContainerDeploymentStatus represents the status of a container deployment
@@ -675,6 +676,13 @@ type ReplicaInfo struct {
 // ContainerEnvVarsRequest represents a request to add/update environment variables for container deployments
 // Used by POST and PATCH /container-deployments/{name}/environment-variables
 type ContainerEnvVarsRequest struct {
+	ContainerName string            `json:"container_name"`
+	Env           []ContainerEnvVar `json:"env"`
+}
+
+// DeploymentEnvironmentVariables represents the grouped environment variables
+// returned by the deployment environment variables endpoints.
+type DeploymentEnvironmentVariables struct {
 	ContainerName string            `json:"container_name"`
 	Env           []ContainerEnvVar `json:"env"`
 }

--- a/test/integration/container_deployments_test.go
+++ b/test/integration/container_deployments_test.go
@@ -362,9 +362,12 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			}
 			t.Fatalf("❌ Failed to get environment variables: %v", err)
 		}
-		t.Logf("✅ Got %d environment variables", len(envVars))
-		for _, env := range envVars {
-			t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+		t.Logf("✅ Got %d environment variable set(s)", len(envVars))
+		for _, envSet := range envVars {
+			t.Logf("   container: %s", envSet.ContainerName)
+			for _, env := range envSet.Env {
+				t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+			}
 		}
 	})
 
@@ -390,14 +393,14 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			},
 		}
 
-		err := client.ContainerDeployments.AddEnvironmentVariables(ctx, depName, addReq)
+		envSets, err := client.ContainerDeployments.AddEnvironmentVariables(ctx, depName, addReq)
 		if err != nil {
 			if apiErr, ok := err.(*verda.APIError); ok && apiErr.StatusCode == 504 {
 				t.Skip("⚠️  Skipping: API timeout (504)")
 			}
 			t.Fatalf("❌ Failed to add environment variables: %v", err)
 		}
-		t.Logf("✅ Added 2 new environment variables")
+		t.Logf("✅ Added environment variables; API returned %d container env set(s)", len(envSets))
 	})
 
 	// Wait a moment for changes to propagate
@@ -417,9 +420,12 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			t.Fatalf("❌ Failed to get environment variables after add: %v", err)
 		}
 
-		t.Logf("✅ Got %d environment variables after add:", len(envVars))
-		for _, env := range envVars {
-			t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+		t.Logf("✅ Got %d environment variable set(s) after add:", len(envVars))
+		for _, envSet := range envVars {
+			t.Logf("   container: %s", envSet.ContainerName)
+			for _, env := range envSet.Env {
+				t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+			}
 		}
 	})
 
@@ -440,14 +446,14 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			},
 		}
 
-		err := client.ContainerDeployments.UpdateEnvironmentVariables(ctx, depName, updateReq)
+		envSets, err := client.ContainerDeployments.UpdateEnvironmentVariables(ctx, depName, updateReq)
 		if err != nil {
 			if apiErr, ok := err.(*verda.APIError); ok && apiErr.StatusCode == 504 {
 				t.Skip("⚠️  Skipping: API timeout (504)")
 			}
 			t.Fatalf("❌ Failed to update environment variables: %v", err)
 		}
-		t.Logf("✅ Updated environment variable NEW_VAR_1")
+		t.Logf("✅ Updated environment variable NEW_VAR_1; API returned %d container env set(s)", len(envSets))
 	})
 
 	// Step 12: DELETE environment variables
@@ -463,14 +469,14 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			},
 		}
 
-		err := client.ContainerDeployments.DeleteEnvironmentVariables(ctx, depName, deleteReq)
+		envSets, err := client.ContainerDeployments.DeleteEnvironmentVariables(ctx, depName, deleteReq)
 		if err != nil {
 			if apiErr, ok := err.(*verda.APIError); ok && apiErr.StatusCode == 504 {
 				t.Skip("⚠️  Skipping: API timeout (504)")
 			}
 			t.Fatalf("❌ Failed to delete environment variables: %v", err)
 		}
-		t.Logf("✅ Deleted environment variable NEW_VAR_2")
+		t.Logf("✅ Deleted environment variable NEW_VAR_2; API returned %d container env set(s)", len(envSets))
 	})
 
 	// Step 13: Verify env var deletion
@@ -487,9 +493,12 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			t.Fatalf("❌ Failed to get environment variables after delete: %v", err)
 		}
 
-		t.Logf("✅ Got %d environment variables after delete:", len(envVars))
-		for _, env := range envVars {
-			t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+		t.Logf("✅ Got %d environment variable set(s) after delete:", len(envVars))
+		for _, envSet := range envVars {
+			t.Logf("   container: %s", envSet.ContainerName)
+			for _, env := range envSet.Env {
+				t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+			}
 		}
 	})
 

--- a/test/integration/serverless_jobs_test.go
+++ b/test/integration/serverless_jobs_test.go
@@ -47,8 +47,7 @@ func TestServerlessJobsListOnly(t *testing.T) {
 // TestServerlessJobsCRUDWithScalingAndEnvVars demonstrates complete CRUD flow
 // Note: Serverless jobs API has limited endpoints compared to container deployments
 // - Environment variables CRUD is NOT supported (set at creation time only)
-// - Scaling update is NOT supported (set at creation time only)
-// - Job deployment PATCH/UPDATE is NOT supported
+// - Scaling does not have a dedicated update endpoint; use job deployment PATCH instead
 func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -135,7 +134,6 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 		}
 		jobCreated = true // Mark as successfully created
 
-		// Extract the container name from the response
 		if len(job.Containers) > 0 {
 			t.Logf("✅ Created job deployment: %s (container: %s)", job.Name, job.Containers[0].Name)
 		} else {
@@ -199,8 +197,40 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 		t.Logf("✅ Retrieved job deployment: %s (containers: %d)", job.Name, len(job.Containers))
 	})
 
-	// Step 3: LIST - List all job deployments
-	t.Run("3. LIST all job deployments", func(t *testing.T) {
+	// Step 3: UPDATE - Patch the existing job deployment
+	t.Run("3. UPDATE job deployment", func(t *testing.T) {
+		if !jobCreated {
+			t.Skip("⚠️  Skipping - job deployment was not created")
+		}
+
+		req := &verda.UpdateJobDeploymentRequest{
+			Scaling: &verda.JobScalingOptions{
+				MaxReplicaCount:        1,
+				QueueMessageTTLSeconds: 300,
+				DeadlineSeconds:        3600,
+			},
+		}
+
+		job, err := client.ServerlessJobs.UpdateJobDeployment(ctx, jobName, req)
+		if err != nil {
+			if apiErr, ok := err.(*verda.APIError); ok {
+				if apiErr.StatusCode == 504 {
+					t.Skip("⚠️  Skipping: API timeout (504) on update operation")
+				}
+				if apiErr.StatusCode == 404 {
+					t.Skip("⚠️  Skipping: Job deployment PATCH endpoint not available (404)")
+				}
+			}
+			t.Fatalf("❌ Failed to update job deployment: %v", err)
+		}
+		if job.Name != jobName {
+			t.Errorf("Expected job name %s, got %s", jobName, job.Name)
+		}
+		t.Logf("✅ Updated job deployment: %s", job.Name)
+	})
+
+	// Step 4: LIST - List all job deployments
+	t.Run("4. LIST all job deployments", func(t *testing.T) {
 		if !jobCreated {
 			t.Skip("⚠️  Skipping - job deployment was not created")
 		}
@@ -227,8 +257,8 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 		t.Logf("✅ Listed %d job deployments, found our job: %s", len(jobs), jobName)
 	})
 
-	// Step 4: GET job deployment status
-	t.Run("4. READ job deployment status", func(t *testing.T) {
+	// Step 5: GET job deployment status
+	t.Run("5. READ job deployment status", func(t *testing.T) {
 		if !jobCreated {
 			t.Skip("⚠️  Skipping - job deployment was not created")
 		}
@@ -243,8 +273,8 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 		t.Logf("✅ Job deployment status: %s", status.Status)
 	})
 
-	// Step 5: GET scaling options (read-only - update not supported for jobs)
-	t.Run("5. READ job scaling options", func(t *testing.T) {
+	// Step 6: GET scaling options
+	t.Run("6. READ job scaling options", func(t *testing.T) {
 		if !jobCreated {
 			t.Skip("⚠️  Skipping - job deployment was not created")
 		}
@@ -260,8 +290,8 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 			scaling.MaxReplicaCount, scaling.QueueMessageTTLSeconds)
 	})
 
-	// Step 6: Pause job deployment
-	t.Run("6. PAUSE job deployment", func(t *testing.T) {
+	// Step 7: Pause job deployment
+	t.Run("7. PAUSE job deployment", func(t *testing.T) {
 		if !jobCreated {
 			t.Skip("⚠️  Skipping - job deployment was not created")
 		}
@@ -279,8 +309,8 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	// Step 7: Resume job deployment
-	t.Run("7. RESUME job deployment", func(t *testing.T) {
+	// Step 8: Resume job deployment
+	t.Run("8. RESUME job deployment", func(t *testing.T) {
 		if !jobCreated {
 			t.Skip("⚠️  Skipping - job deployment was not created")
 		}
@@ -296,8 +326,8 @@ func TestServerlessJobsCRUDWithScalingAndEnvVars(t *testing.T) {
 		}
 	})
 
-	// Step 8: Purge job queue
-	t.Run("8. PURGE job deployment queue", func(t *testing.T) {
+	// Step 9: Purge job queue
+	t.Run("9. PURGE job deployment queue", func(t *testing.T) {
 		if !jobCreated {
 			t.Skip("⚠️  Skipping - job deployment was not created")
 		}


### PR DESCRIPTION
## Description
 
Sync the `/v1/container-deployments` SDK surface with the Datacrunch OpenAPI spec by aligning environment-variable endpoint responses and tightening deployment PATCH behavior.
 
## Type of Change
 
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates
 
## Changes Made
 
- Returned spec-aligned grouped environment variable payloads for container deployment env-var endpoints.
- Rejected deployment PATCH requests that incorrectly include `scaling`, directing callers to the dedicated scaling endpoint.
- Updated mock server behavior plus unit/integration coverage for env-var CRUD and PATCH validation.
 
## Testing
 
- [x] Unit tests pass locally (`make test-unit`)
- [x] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] All CI checks pass
 
**Test Coverage:**
Ran targeted unit coverage with:
- `go test ./pkg/verda -run 'TestContainerDeploymentsService'`
 
Also updated integration test expectations for grouped env-var responses. A local Go `1.24.13` toolchain was used because the base environment only had Go `1.22.2`.
 
## Checklist
 
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
 
## Related Issues
 
Closes #
Related to #
 
## Additional Context
 
This PR is the container-deployments slice of the broader OpenAPI sync effort and is isolated to `/v1/container-deployments` behavior.
 
---
 
**Note:** Pre-commit hooks will run automatically when you commit. Make sure to run `make check` before pushing to ensure all CI checks will pass.