### PR TITLE
Fix/volumes openapi sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(serverless-jobs): Add PATCH support for updating existing job deployments
 
 ### Fixed
+- fix(volumes): Align delete requests, trash listing, and clone payloads with the OpenAPI volume contract
 - fix(testutil): Deduplicate mock server PATCH handlers to satisfy golangci-lint
 
 ## [v1.2.2] - 2026-02-25

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -77,11 +77,13 @@ type CreateInstanceRequest struct {
 
 // VolumeCreateRequest represents a volume to be created
 type VolumeCreateRequest struct {
-	Size              int    `json:"size"`
-	Type              string `json:"type"`
-	Name              string `json:"name"`
-	LocationCode      string `json:"location_code,omitempty"`
-	OnSpotDiscontinue string `json:"on_spot_discontinue,omitempty"`
+	Size              int      `json:"size"`
+	Type              string   `json:"type"`
+	Name              string   `json:"name"`
+	LocationCode      string   `json:"location_code,omitempty"`
+	OnSpotDiscontinue string   `json:"on_spot_discontinue,omitempty"`
+	InstanceID        *string  `json:"instance_id,omitempty"`
+	InstanceIDs       []string `json:"instance_ids,omitempty"`
 }
 
 // VolumeAttachRequest represents a request to attach a volume to an instance
@@ -96,11 +98,15 @@ type VolumeDetachRequest struct {
 
 // VolumeActionRequest represents an action to perform on volumes
 type VolumeActionRequest struct {
-	ID     string `json:"id"`
-	Action string `json:"action"`
-	Name   string `json:"name,omitempty"`
-	Type   string `json:"type,omitempty"`
-	Size   int    `json:"size,omitempty"`
+	ID           string   `json:"id"`
+	Action       string   `json:"action"`
+	Name         string   `json:"name,omitempty"`
+	Type         string   `json:"type,omitempty"`
+	Size         int      `json:"size,omitempty"`
+	InstanceID   string   `json:"instance_id,omitempty"`
+	InstanceIDs  []string `json:"instance_ids,omitempty"`
+	IsPermanent  *bool    `json:"is_permanent,omitempty"`
+	LocationCode string   `json:"location_code,omitempty"`
 }
 
 // VolumeCloneRequest represents a request to clone a volume
@@ -117,6 +123,11 @@ type VolumeResizeRequest struct {
 // VolumeRenameRequest represents a request to rename a volume
 type VolumeRenameRequest struct {
 	Name string `json:"name"`
+}
+
+// DeleteVolumeRequest represents options for deleting a volume.
+type DeleteVolumeRequest struct {
+	IsPermanent *bool `json:"is_permanent,omitempty"`
 }
 
 // OSVolumeCreateRequest represents OS volume configuration
@@ -202,6 +213,13 @@ type Volume struct {
 	MonthlyPrice             float64                  `json:"monthly_price"`
 	Currency                 string                   `json:"currency"`
 	LongTerm                 *VolumeLongTerm          `json:"long_term"`
+}
+
+// TrashedVolume represents a volume returned by /volumes/trash.
+type TrashedVolume struct {
+	Volume
+	DeletedAt            time.Time `json:"deleted_at"`
+	IsPermanentlyDeleted bool      `json:"is_permanently_deleted"`
 }
 
 // VolumeType represents available volume type specifications

--- a/pkg/verda/volumes.go
+++ b/pkg/verda/volumes.go
@@ -43,6 +43,15 @@ func (s *VolumeService) GetVolume(ctx context.Context, id string) (*Volume, erro
 	return &volume, nil
 }
 
+func (s *VolumeService) ListTrashVolumes(ctx context.Context) ([]TrashedVolume, error) {
+	volumes, _, err := getRequest[[]TrashedVolume](ctx, s.client, "/volumes/trash")
+	if err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
+}
+
 func (s *VolumeService) CreateVolume(ctx context.Context, req VolumeCreateRequest) (string, error) {
 	if req.LocationCode == "" {
 		req.LocationCode = LocationFIN01
@@ -75,44 +84,46 @@ func (s *VolumeService) createVolumeWithPlainTextResponse(ctx context.Context, r
 
 func (s *VolumeService) DeleteVolume(ctx context.Context, id string, force bool) error {
 	path := fmt.Sprintf("/volumes/%s", id)
+
+	var req *DeleteVolumeRequest
 	if force {
-		path += "?force=true"
+		isPermanent := true
+		req = &DeleteVolumeRequest{IsPermanent: &isPermanent}
 	}
 
-	_, err := deleteRequestAllowEmptyResponse(ctx, s.client, path)
+	_, err := deleteRequestWithBody(ctx, s.client, path, req)
 	return err
 }
 
 // AttachVolume attaches a volume - instance must be shut down first
 func (s *VolumeService) AttachVolume(ctx context.Context, volumeID string, req VolumeAttachRequest) error {
-	// Use map to combine action fields with instance_id
-	payload := map[string]interface{}{
-		"id":          volumeID,
-		"action":      VolumeActionAttach,
-		"instance_id": req.InstanceID,
+	actionReq := VolumeActionRequest{
+		ID:         volumeID,
+		Action:     VolumeActionAttach,
+		InstanceID: req.InstanceID,
 	}
-	_, err := putRequestAllowEmptyResponse(ctx, s.client, "/volumes", payload)
+	_, err := putRequestAllowEmptyResponse(ctx, s.client, "/volumes", actionReq)
 	return err
 }
 
 // DetachVolume detaches a volume - instance must be shut down first
 func (s *VolumeService) DetachVolume(ctx context.Context, volumeID string, req VolumeDetachRequest) error {
-	payload := map[string]interface{}{
-		"id":          volumeID,
-		"action":      VolumeActionDetach,
-		"instance_id": req.InstanceID,
+	actionReq := VolumeActionRequest{
+		ID:         volumeID,
+		Action:     VolumeActionDetach,
+		InstanceID: req.InstanceID,
 	}
-	_, err := putRequestAllowEmptyResponse(ctx, s.client, "/volumes", payload)
+	_, err := putRequestAllowEmptyResponse(ctx, s.client, "/volumes", actionReq)
 	return err
 }
 
 // CloneVolume clones a volume and returns the new volume ID
 func (s *VolumeService) CloneVolume(ctx context.Context, volumeID string, req VolumeCloneRequest) (string, error) {
 	actionReq := VolumeActionRequest{
-		ID:     volumeID,
-		Action: VolumeActionClone,
-		Name:   req.Name,
-		Type:   req.LocationCode, // Note: Python SDK uses 'type' field for location
+		ID:           volumeID,
+		Action:       VolumeActionClone,
+		Name:         req.Name,
+		LocationCode: req.LocationCode,
 	}
 
 	resp, err := s.client.makeRequest(ctx, http.MethodPut, "/volumes", actionReq)

--- a/pkg/verda/volumes_test.go
+++ b/pkg/verda/volumes_test.go
@@ -175,6 +175,46 @@ func TestVolumeService_GetVolume(t *testing.T) {
 	})
 }
 
+func TestVolumeService_ListTrashVolumes(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	client := NewTestClient(mockServer)
+
+	mockServer.SetHandler(http.MethodGet, "/volumes/trash", func(w http.ResponseWriter, r *http.Request) {
+		volumes := []TrashedVolume{
+			{
+				Volume: Volume{
+					ID:       "vol_trash_123",
+					Name:     "Trashed Volume",
+					Size:     100,
+					Type:     VolumeTypeNVMe,
+					Status:   VolumeStatusDeleted,
+					Location: LocationFIN01,
+				},
+				IsPermanentlyDeleted: false,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(volumes)
+	})
+
+	t.Run("list trashed volumes", func(t *testing.T) {
+		ctx := context.Background()
+		volumes, err := client.Volumes.ListTrashVolumes(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(volumes) != 1 {
+			t.Fatalf("expected 1 trashed volume, got %d", len(volumes))
+		}
+		if volumes[0].ID != "vol_trash_123" {
+			t.Fatalf("expected trashed volume ID vol_trash_123, got %s", volumes[0].ID)
+		}
+	})
+}
+
 func TestVolumeService_CreateVolume(t *testing.T) {
 	mockServer := testutil.NewMockServer()
 	defer mockServer.Close()
@@ -245,7 +285,22 @@ func TestVolumeService_DeleteVolume(t *testing.T) {
 
 	// Set up mock response for volume deletion
 	mockServer.SetHandler(http.MethodDelete, "/volumes/vol_123", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
+		if r.URL.RawQuery != "" {
+			t.Fatalf("expected delete volume request without query parameters, got %s", r.URL.RawQuery)
+		}
+
+		var req DeleteVolumeRequest
+		if r.ContentLength > 0 {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed decoding delete request body: %v", err)
+			}
+		}
+
+		if req.IsPermanent != nil && !*req.IsPermanent {
+			t.Fatalf("expected is_permanent to be true when present")
+		}
+
+		w.WriteHeader(http.StatusAccepted)
 	})
 
 	t.Run("delete volume", func(t *testing.T) {
@@ -400,6 +455,17 @@ func TestVolumeService_CloneVolume(t *testing.T) {
 				_, _ = w.Write([]byte("name required"))
 				return
 			}
+			locationCode, _ := actionReq["location_code"].(string)
+			if locationCode != LocationFIN01 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("location_code required"))
+				return
+			}
+			if _, hasType := actionReq["type"]; hasType {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("type should not be sent for clone"))
+				return
+			}
 			// Return array of volume IDs (matching Python SDK behavior)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -547,9 +613,15 @@ func TestVolumeService_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("attach volume to non-existent instance", func(t *testing.T) {
-		mockServer.SetHandler(http.MethodPost, "/volumes/vol_123/attach", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"error": "Instance not found"}`))
+		mockServer.SetHandler(http.MethodPut, "/volumes", func(w http.ResponseWriter, r *http.Request) {
+			var actionReq VolumeActionRequest
+			_ = json.NewDecoder(r.Body).Decode(&actionReq)
+			if actionReq.Action == VolumeActionAttach && actionReq.InstanceID == "nonexistent" {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error": "Instance not found"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
 		})
 
 		req := VolumeAttachRequest{
@@ -564,9 +636,15 @@ func TestVolumeService_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("resize volume to smaller size", func(t *testing.T) {
-		mockServer.SetHandler(http.MethodPost, "/volumes/vol_123/resize", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error": "Cannot shrink volume"}`))
+		mockServer.SetHandler(http.MethodPut, "/volumes", func(w http.ResponseWriter, r *http.Request) {
+			var actionReq VolumeActionRequest
+			_ = json.NewDecoder(r.Body).Decode(&actionReq)
+			if actionReq.Action == VolumeActionResize && actionReq.Size == 50 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error": "Cannot shrink volume"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
 		})
 
 		req := VolumeResizeRequest{


### PR DESCRIPTION
## Description
 
Align the `/v1/volumes` SDK surface with the OpenAPI contract by switching volume deletion to the request-body shape, adding `/volumes/trash`, and correcting clone payload fields.
 
## Type of Change
 
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates
 
## Changes Made
 
- [x] Switch volume deletion to the OpenAPI-aligned JSON body instead of a query parameter
- [x] Add the missing `/v1/volumes/trash` SDK method and response type
- [x] Update clone payloads, tests, and changelog after rebasing onto latest upstream `main`
 
## Testing
 
- [x] Unit tests pass locally (`make test-unit`)
- [x] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] All CI checks pass
 
**Test Coverage:**
Ran `go test ./pkg/verda -run 'TestVolumeService'` with Go 1.25.8.
 
## Checklist
 
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
 
## Related Issues
 
Closes #
Related to #
 
## Additional Context
 
Rebased onto the latest `verda-cloud/verdacloud-sdk-go` `main` to pick up the Go 1.25 security/vulnerability fixes.
 
---
 
**Note:** Pre-commit hooks will run automatically when you commit. Make sure to run `make check` before pushing to ensure all CI checks will pass.
 