### PR TITLE
Feat/container deployments openapi sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(serverless-jobs): Add PATCH support for updating existing job deployments
 
 ### Fixed
+- fix(container-deployments): Align environment variable response payloads and enforce scaling updates via the dedicated scaling endpoint
 - fix(testutil): Deduplicate mock server PATCH handlers to satisfy golangci-lint
 
 ## [v1.2.2] - 2026-02-25

--- a/pkg/verda/container_deployments.go
+++ b/pkg/verda/container_deployments.go
@@ -10,6 +10,55 @@ type ContainerDeploymentsService struct {
 	client *Client
 }
 
+func validateUpdateDeploymentRequest(req *UpdateDeploymentRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+
+	if req.Scaling != nil {
+		return fmt.Errorf("deployment scaling updates must use UpdateDeploymentScaling")
+	}
+
+	for i, container := range req.Containers {
+		if container.Name == "" {
+			return fmt.Errorf("containers[%d].name is required", i)
+		}
+		if container.Image != "" && isLatestTag(container.Image) {
+			return fmt.Errorf("containers[%d].image: 'latest' tag is not allowed, please specify a specific version tag (e.g., nginx:1.25.3)", i)
+		}
+	}
+
+	return nil
+}
+
+func validateContainerEnvironmentVariablesRequest(req *ContainerEnvVarsRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ContainerName == "" {
+		return fmt.Errorf("container_name is required")
+	}
+	if len(req.Env) == 0 {
+		return fmt.Errorf("env array cannot be empty")
+	}
+
+	return nil
+}
+
+func validateDeleteContainerEnvironmentVariablesRequest(req *DeleteContainerEnvVarsRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ContainerName == "" {
+		return fmt.Errorf("container_name is required")
+	}
+	if len(req.Env) == 0 {
+		return fmt.Errorf("env array cannot be empty")
+	}
+
+	return nil
+}
+
 // GetDeployments retrieves all container deployments
 // projectID is optional - if empty, uses default project
 func (s *ContainerDeploymentsService) GetDeployments(ctx context.Context) ([]ContainerDeployment, error) {
@@ -116,15 +165,12 @@ func (s *ContainerDeploymentsService) GetDeploymentByName(ctx context.Context, d
 }
 
 func (s *ContainerDeploymentsService) UpdateDeployment(ctx context.Context, deploymentName string, req *UpdateDeploymentRequest) (*ContainerDeployment, error) {
-	// Validate required fields for update
-	if req == nil {
-		return nil, fmt.Errorf("request cannot be nil")
-	}
 	if deploymentName == "" {
 		return nil, fmt.Errorf("deploymentName is required")
 	}
-	// Note: UpdateDeployment is a PATCH operation, so partial updates are allowed.
-	// Containers are optional - you can update just scaling, compute, or other fields.
+	if err := validateUpdateDeploymentRequest(req); err != nil {
+		return nil, err
+	}
 
 	path := fmt.Sprintf("/container-deployments/%s", deploymentName)
 	deployment, _, err := patchRequest[ContainerDeployment](ctx, s.client, path, req)
@@ -236,70 +282,64 @@ func (s *ContainerDeploymentsService) GetDeploymentReplicas(ctx context.Context,
 	return &replicas, nil
 }
 
-func (s *ContainerDeploymentsService) GetEnvironmentVariables(ctx context.Context, deploymentName string) ([]ContainerEnvVar, error) {
+func (s *ContainerDeploymentsService) GetEnvironmentVariables(ctx context.Context, deploymentName string) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
 		return nil, fmt.Errorf("deploymentName is required")
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	envVars, _, err := getRequest[[]ContainerEnvVar](ctx, s.client, path)
+	envVars, _, err := getRequest[[]DeploymentEnvironmentVariables](ctx, s.client, path)
 	if err != nil {
 		return nil, err
 	}
 	return envVars, nil
 }
 
-func (s *ContainerDeploymentsService) AddEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) error {
+func (s *ContainerDeploymentsService) AddEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
-		return fmt.Errorf("deploymentName is required")
+		return nil, fmt.Errorf("deploymentName is required")
 	}
-	if req == nil {
-		return fmt.Errorf("request cannot be nil")
-	}
-	if req.ContainerName == "" {
-		return fmt.Errorf("container_name is required")
-	}
-	if len(req.Env) == 0 {
-		return fmt.Errorf("env array cannot be empty")
+	if err := validateContainerEnvironmentVariablesRequest(req); err != nil {
+		return nil, err
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	_, _, err := postRequest[interface{}](ctx, s.client, path, req)
-	return err
+	envVars, _, err := postRequest[[]DeploymentEnvironmentVariables](ctx, s.client, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVars, nil
 }
 
-func (s *ContainerDeploymentsService) UpdateEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) error {
+func (s *ContainerDeploymentsService) UpdateEnvironmentVariables(ctx context.Context, deploymentName string, req *ContainerEnvVarsRequest) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
-		return fmt.Errorf("deploymentName is required")
+		return nil, fmt.Errorf("deploymentName is required")
 	}
-	if req == nil {
-		return fmt.Errorf("request cannot be nil")
-	}
-	if req.ContainerName == "" {
-		return fmt.Errorf("container_name is required")
-	}
-	if len(req.Env) == 0 {
-		return fmt.Errorf("env array cannot be empty")
+	if err := validateContainerEnvironmentVariablesRequest(req); err != nil {
+		return nil, err
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	_, _, err := patchRequest[interface{}](ctx, s.client, path, req)
-	return err
+	envVars, _, err := patchRequest[[]DeploymentEnvironmentVariables](ctx, s.client, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVars, nil
 }
 
-func (s *ContainerDeploymentsService) DeleteEnvironmentVariables(ctx context.Context, deploymentName string, req *DeleteContainerEnvVarsRequest) error {
+func (s *ContainerDeploymentsService) DeleteEnvironmentVariables(ctx context.Context, deploymentName string, req *DeleteContainerEnvVarsRequest) ([]DeploymentEnvironmentVariables, error) {
 	if deploymentName == "" {
-		return fmt.Errorf("deploymentName is required")
+		return nil, fmt.Errorf("deploymentName is required")
 	}
-	if req == nil {
-		return fmt.Errorf("request cannot be nil")
-	}
-	if req.ContainerName == "" {
-		return fmt.Errorf("container_name is required")
-	}
-	if len(req.Env) == 0 {
-		return fmt.Errorf("env array cannot be empty")
+	if err := validateDeleteContainerEnvironmentVariablesRequest(req); err != nil {
+		return nil, err
 	}
 	path := fmt.Sprintf("/container-deployments/%s/environment-variables", deploymentName)
-	_, err := deleteRequestWithBody(ctx, s.client, path, req)
-	return err
+	envVars, _, err := requestWithBody[[]DeploymentEnvironmentVariables](ctx, s.client, "DELETE", path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVars, nil
 }
 
 func (s *ContainerDeploymentsService) GetServerlessComputeResources(ctx context.Context) ([]ComputeResource, error) {

--- a/pkg/verda/container_deployments_test.go
+++ b/pkg/verda/container_deployments_test.go
@@ -256,10 +256,10 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 
 	t.Run("validation - empty deployment name", func(t *testing.T) {
 		ctx := context.Background()
-		maxReplicas := 2
 		req := &UpdateDeploymentRequest{
-			Scaling: &ContainerScalingOptions{
-				MaxReplicaCount: maxReplicas,
+			Compute: &ContainerCompute{
+				Name: "H100",
+				Size: 1,
 			},
 		}
 		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "", req)
@@ -268,19 +268,19 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("partial update - scaling only", func(t *testing.T) {
+	t.Run("validation - scaling updates must use dedicated endpoint", func(t *testing.T) {
 		ctx := context.Background()
-		maxReplicas := 3
 		req := &UpdateDeploymentRequest{
 			Scaling: &ContainerScalingOptions{
-				MaxReplicaCount: maxReplicas,
+				MaxReplicaCount: 3,
 			},
 		}
-		// This should not fail validation - partial updates are allowed
 		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "test-deployment", req)
-		// The mock server may return an error, but validation should pass
-		if err != nil && err.Error() == "at least one container is required" {
-			t.Error("UpdateDeployment should allow partial updates without containers")
+		if err == nil {
+			t.Fatal("expected error for scaling update on deployment patch")
+		}
+		if err.Error() != "deployment scaling updates must use UpdateDeploymentScaling" {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -290,7 +290,7 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 			Containers: []CreateDeploymentContainer{
 				{
 					Name:        "my-container",
-					Image:       "nginx:latest",
+					Image:       "nginx:1.25.3",
 					ExposedPort: 8080,
 				},
 			},
@@ -309,16 +309,100 @@ func TestContainerDeploymentsService_UpdateDeployment(t *testing.T) {
 		req := &UpdateDeploymentRequest{
 			Containers: []CreateDeploymentContainer{
 				{
-					Image:       "nginx:latest",
+					Image:       "nginx:1.25.3",
 					ExposedPort: 8080,
 					// Name is missing - API requires it for updates
 				},
 			},
 		}
-		// Should fail - API requires container name for updates
 		_, err := client.ContainerDeployments.UpdateDeployment(ctx, "test-deployment", req)
 		if err == nil {
 			t.Error("expected error when container name is missing")
+		}
+	})
+}
+
+func TestContainerDeploymentsService_EnvironmentVariables(t *testing.T) {
+	mockServer := testutil.NewMockServer()
+	defer mockServer.Close()
+
+	client := NewTestClient(mockServer)
+
+	t.Run("get environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.GetEnvironmentVariables(ctx, "flux")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 {
+			t.Fatalf("expected 1 environment variable set, got %d", len(envSets))
+		}
+		if envSets[0].ContainerName != "flux-0" {
+			t.Fatalf("expected container name flux-0, got %s", envSets[0].ContainerName)
+		}
+		if len(envSets[0].Env) != 1 {
+			t.Fatalf("expected 1 environment variable, got %d", len(envSets[0].Env))
+		}
+		if envSets[0].Env[0].Name != "MY_ENV_VAR" {
+			t.Fatalf("expected environment variable MY_ENV_VAR, got %s", envSets[0].Env[0].Name)
+		}
+	})
+
+	t.Run("add environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.AddEnvironmentVariables(ctx, "flux", &ContainerEnvVarsRequest{
+			ContainerName: "flux-0",
+			Env: []ContainerEnvVar{
+				{
+					Name:                     "NEW_ENV_VAR",
+					ValueOrReferenceToSecret: "new-value",
+					Type:                     "plain",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 || len(envSets[0].Env) != 2 {
+			t.Fatalf("expected added environment variables to be returned, got %+v", envSets)
+		}
+	})
+
+	t.Run("update environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.UpdateEnvironmentVariables(ctx, "flux", &ContainerEnvVarsRequest{
+			ContainerName: "flux-0",
+			Env: []ContainerEnvVar{
+				{
+					Name:                     "MY_ENV_VAR",
+					ValueOrReferenceToSecret: "updated-value",
+					Type:                     "plain",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 || envSets[0].Env[0].ValueOrReferenceToSecret != "updated-value" {
+			t.Fatalf("expected updated environment variables to be returned, got %+v", envSets)
+		}
+	})
+
+	t.Run("delete environment variables", func(t *testing.T) {
+		ctx := context.Background()
+		envSets, err := client.ContainerDeployments.DeleteEnvironmentVariables(ctx, "flux", &DeleteContainerEnvVarsRequest{
+			ContainerName: "flux-0",
+			Env:           []string{"MY_ENV_VAR"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(envSets) != 1 || len(envSets[0].Env) != 0 {
+			t.Fatalf("expected empty environment variable set after delete, got %+v", envSets)
 		}
 	})
 }

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -584,6 +584,8 @@ func (ms *MockServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		ms.handleGetDeploymentScaling(w, r)
 	case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/scaling") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
 		ms.handleUpdateDeploymentScaling(w, r)
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/environment-variables") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
+		ms.handleGetEnvironmentVariables(w, r)
 	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/environment-variables") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
 		ms.handleAddEnvironmentVariables(w, r)
 	case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/environment-variables") && strings.HasPrefix(r.URL.Path, "/container-deployments/"):
@@ -1780,8 +1782,37 @@ func (ms *MockServer) handleCreateContainerDeployment(w http.ResponseWriter, _ *
 func (ms *MockServer) handleUpdateContainerDeployment(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	if !decodeAndValidateNamedContainers(w, r) {
+	var req map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid JSON"})
 		return
+	}
+
+	if _, hasScaling := req["scaling"]; hasScaling {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"message": "deployment scaling updates must use /container-deployments/{deployment_name}/scaling"})
+		return
+	}
+
+	if containers, ok := req["containers"].([]interface{}); ok && len(containers) > 0 {
+		for i, c := range containers {
+			container, ok := c.(map[string]interface{})
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]string{"error": "invalid container format"})
+				return
+			}
+
+			name, hasName := container["name"]
+			if !hasName || name == nil || name == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]interface{}{
+					"message": "containers." + string(rune('0'+i)) + ".name should not be null or undefined",
+				})
+				return
+			}
+		}
 	}
 
 	writeBytes(w, []byte(mockUpdatedContainerDeploymentResponse))
@@ -1798,48 +1829,67 @@ func (ms *MockServer) handleUpdateDeploymentScaling(w http.ResponseWriter, _ *ht
 	writeBytes(w, []byte(mockScalingOptionsResponse))
 }
 
+func (ms *MockServer) handleGetEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": [
+				{
+					"name": "MY_ENV_VAR",
+					"value_or_reference_to_secret": "my-value",
+					"type": "plain"
+				}
+			]
+		}
+	]`))
+}
+
 func (ms *MockServer) handleAddEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-
-	// Sample request:
-	// {
-	//   "container_name": "flux-0",
-	//   "env": [
-	//     {
-	//       "name": "MY_ENV_VAR",
-	//       "value_or_reference_to_secret": "my-value",
-	//       "type": "plain"
-	//     }
-	//   ]
-	// }
-
-	// Returns success with no body or empty object
-	writeBytes(w, []byte(`{}`))
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": [
+				{
+					"name": "MY_ENV_VAR",
+					"value_or_reference_to_secret": "my-value",
+					"type": "plain"
+				},
+				{
+					"name": "NEW_ENV_VAR",
+					"value_or_reference_to_secret": "new-value",
+					"type": "plain"
+				}
+			]
+		}
+	]`))
 }
 
 func (ms *MockServer) handleUpdateEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-
-	// Sample request:
-	// {
-	//   "container_name": "flux-0",
-	//   "env": [
-	//     {
-	//       "name": "MY_ENV_VAR",
-	//       "value_or_reference_to_secret": "my-value",
-	//       "type": "plain"
-	//     }
-	//   ]
-	// }
-
-	// Returns success with no body or empty object
-	writeBytes(w, []byte(`{}`))
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": [
+				{
+					"name": "MY_ENV_VAR",
+					"value_or_reference_to_secret": "updated-value",
+					"type": "plain"
+				}
+			]
+		}
+	]`))
 }
 
 func (ms *MockServer) handleDeleteEnvironmentVariables(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNoContent)
+	writeBytes(w, []byte(`[
+		{
+			"container_name": "flux-0",
+			"env": []
+		}
+	]`))
 }
 
 func (ms *MockServer) handleGetServerlessComputeResources(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -620,11 +620,12 @@ type CreateDeploymentContainer struct {
 
 // UpdateDeploymentRequest represents a request to update a deployment
 type UpdateDeploymentRequest struct {
-	IsSpot                    *bool                       `json:"is_spot,omitempty"`
-	Compute                   *ContainerCompute           `json:"compute,omitempty"`
-	ContainerRegistrySettings *ContainerRegistrySettings  `json:"container_registry_settings,omitempty"`
-	Scaling                   *ContainerScalingOptions    `json:"scaling,omitempty"`
-	Containers                []CreateDeploymentContainer `json:"containers,omitempty"`
+	IsSpot                    *bool                      `json:"is_spot,omitempty"`
+	Compute                   *ContainerCompute          `json:"compute,omitempty"`
+	ContainerRegistrySettings *ContainerRegistrySettings `json:"container_registry_settings,omitempty"`
+	// Deprecated: use UpdateDeploymentScaling with /container-deployments/{name}/scaling.
+	Scaling    *ContainerScalingOptions    `json:"-"`
+	Containers []CreateDeploymentContainer `json:"containers,omitempty"`
 }
 
 // ContainerDeploymentStatus represents the status of a container deployment
@@ -696,6 +697,13 @@ type ReplicaInfo struct {
 // ContainerEnvVarsRequest represents a request to add/update environment variables for container deployments
 // Used by POST and PATCH /container-deployments/{name}/environment-variables
 type ContainerEnvVarsRequest struct {
+	ContainerName string            `json:"container_name"`
+	Env           []ContainerEnvVar `json:"env"`
+}
+
+// DeploymentEnvironmentVariables represents the grouped environment variables
+// returned by the deployment environment variables endpoints.
+type DeploymentEnvironmentVariables struct {
 	ContainerName string            `json:"container_name"`
 	Env           []ContainerEnvVar `json:"env"`
 }

--- a/test/integration/container_deployments_test.go
+++ b/test/integration/container_deployments_test.go
@@ -362,9 +362,12 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			}
 			t.Fatalf("❌ Failed to get environment variables: %v", err)
 		}
-		t.Logf("✅ Got %d environment variables", len(envVars))
-		for _, env := range envVars {
-			t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+		t.Logf("✅ Got %d environment variable set(s)", len(envVars))
+		for _, envSet := range envVars {
+			t.Logf("   container: %s", envSet.ContainerName)
+			for _, env := range envSet.Env {
+				t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+			}
 		}
 	})
 
@@ -390,14 +393,14 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			},
 		}
 
-		err := client.ContainerDeployments.AddEnvironmentVariables(ctx, depName, addReq)
+		envSets, err := client.ContainerDeployments.AddEnvironmentVariables(ctx, depName, addReq)
 		if err != nil {
 			if apiErr, ok := err.(*verda.APIError); ok && apiErr.StatusCode == 504 {
 				t.Skip("⚠️  Skipping: API timeout (504)")
 			}
 			t.Fatalf("❌ Failed to add environment variables: %v", err)
 		}
-		t.Logf("✅ Added 2 new environment variables")
+		t.Logf("✅ Added environment variables; API returned %d container env set(s)", len(envSets))
 	})
 
 	// Wait a moment for changes to propagate
@@ -417,9 +420,12 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			t.Fatalf("❌ Failed to get environment variables after add: %v", err)
 		}
 
-		t.Logf("✅ Got %d environment variables after add:", len(envVars))
-		for _, env := range envVars {
-			t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+		t.Logf("✅ Got %d environment variable set(s) after add:", len(envVars))
+		for _, envSet := range envVars {
+			t.Logf("   container: %s", envSet.ContainerName)
+			for _, env := range envSet.Env {
+				t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+			}
 		}
 	})
 
@@ -440,14 +446,14 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			},
 		}
 
-		err := client.ContainerDeployments.UpdateEnvironmentVariables(ctx, depName, updateReq)
+		envSets, err := client.ContainerDeployments.UpdateEnvironmentVariables(ctx, depName, updateReq)
 		if err != nil {
 			if apiErr, ok := err.(*verda.APIError); ok && apiErr.StatusCode == 504 {
 				t.Skip("⚠️  Skipping: API timeout (504)")
 			}
 			t.Fatalf("❌ Failed to update environment variables: %v", err)
 		}
-		t.Logf("✅ Updated environment variable NEW_VAR_1")
+		t.Logf("✅ Updated environment variable NEW_VAR_1; API returned %d container env set(s)", len(envSets))
 	})
 
 	// Step 12: DELETE environment variables
@@ -463,14 +469,14 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			},
 		}
 
-		err := client.ContainerDeployments.DeleteEnvironmentVariables(ctx, depName, deleteReq)
+		envSets, err := client.ContainerDeployments.DeleteEnvironmentVariables(ctx, depName, deleteReq)
 		if err != nil {
 			if apiErr, ok := err.(*verda.APIError); ok && apiErr.StatusCode == 504 {
 				t.Skip("⚠️  Skipping: API timeout (504)")
 			}
 			t.Fatalf("❌ Failed to delete environment variables: %v", err)
 		}
-		t.Logf("✅ Deleted environment variable NEW_VAR_2")
+		t.Logf("✅ Deleted environment variable NEW_VAR_2; API returned %d container env set(s)", len(envSets))
 	})
 
 	// Step 13: Verify env var deletion
@@ -487,9 +493,12 @@ func TestContainerDeploymentsCRUDWithScalingAndEnvVars(t *testing.T) {
 			t.Fatalf("❌ Failed to get environment variables after delete: %v", err)
 		}
 
-		t.Logf("✅ Got %d environment variables after delete:", len(envVars))
-		for _, env := range envVars {
-			t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+		t.Logf("✅ Got %d environment variable set(s) after delete:", len(envVars))
+		for _, envSet := range envVars {
+			t.Logf("   container: %s", envSet.ContainerName)
+			for _, env := range envSet.Env {
+				t.Logf("   - %s=%s (type: %s)", env.Name, env.ValueOrReferenceToSecret, env.Type)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Description
 
Sync the `/v1/container-deployments` SDK surface with the Datacrunch OpenAPI spec by aligning environment-variable endpoint responses and tightening deployment PATCH behavior.
 
## Type of Change
 
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates
 
## Changes Made
 
- [x] Return spec-aligned grouped environment variable payloads for container deployment env-var endpoints
- [x] Reject deployment PATCH requests that incorrectly include `scaling`, directing callers to the dedicated scaling endpoint
- [x] Update mock server, tests, changelog, and branch base after rebasing onto latest upstream `main`
 
## Testing
 
- [ ] Unit tests pass locally (`make test-unit`)
- [ ] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [ ] All CI checks pass
 
**Test Coverage:**
Ran `go test ./pkg/verda -run 'TestContainerDeploymentsService'` with Go 1.25.8.
 
## Checklist
 
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
 
## Related Issues
 
Closes #
Related to #
 
## Additional Context
 
Rebased onto the latest `verda-cloud/verdacloud-sdk-go` `main` to pick up the Go 1.25 security/vulnerability fixes.
 
---
 
**Note:** Pre-commit hooks will run automatically when you commit. Make sure to run `make check` before pushing to ensure all CI checks will pass.