### PR TITLE
Feat/instances openapi sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- feat(instances): Add OpenAPI-aligned instance list filters plus typed action helper wrappers
 - Add spot volume removal policy (`on_spot_discontinue`) and related constants
 - Add `delete_permanently` field to `InstanceActionRequest`
 - Add `InstanceActionResult` type for action responses and handle response code properly

--- a/pkg/verda/instances.go
+++ b/pkg/verda/instances.go
@@ -15,10 +15,19 @@ type InstanceService struct {
 }
 
 func (s *InstanceService) Get(ctx context.Context, status string) ([]Instance, error) {
+	return s.GetWithOptions(ctx, InstanceListOptions{Status: status})
+}
+
+func (s *InstanceService) GetWithOptions(ctx context.Context, options InstanceListOptions) ([]Instance, error) {
 	path := "/instances"
-	if status != "" {
-		params := url.Values{}
-		params.Set("status", status)
+	params := url.Values{}
+	if options.Status != "" {
+		params.Set("status", options.Status)
+	}
+	if options.ComputeID != "" {
+		params.Set("computeId", options.ComputeID)
+	}
+	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
 
@@ -131,6 +140,21 @@ func (s *InstanceService) Action(ctx context.Context, req InstanceActionRequest)
 	}
 }
 
+func (s *InstanceService) ActionDetailed(
+	ctx context.Context,
+	ids []string,
+	action string,
+	volumeIDs []string,
+	deletePermanently bool,
+) ([]InstanceActionResult, error) {
+	return s.Action(ctx, InstanceActionRequest{
+		Action:            action,
+		ID:                ids,
+		VolumeIDs:         volumeIDs,
+		DeletePermanently: deletePermanently,
+	})
+}
+
 func (s *InstanceService) GetLocationAvailabilities(ctx context.Context) ([]LocationAvailability, error) {
 	availabilities, _, err := getRequest[[]LocationAvailability](ctx, s.client, "/instance-availability")
 	if err != nil {
@@ -200,6 +224,10 @@ func (s *InstanceService) Shutdown(ctx context.Context, ids ...string) error {
 func (s *InstanceService) Delete(ctx context.Context, ids []string, volumeIDs []string, deletePermanently bool) error {
 	_, err := s.Action(ctx, InstanceActionRequest{Action: ActionDelete, ID: ids, VolumeIDs: volumeIDs, DeletePermanently: deletePermanently})
 	return err
+}
+
+func (s *InstanceService) DeletePermanently(ctx context.Context, volumeIDs []string, ids ...string) ([]InstanceActionResult, error) {
+	return s.ActionDetailed(ctx, ids, ActionDelete, volumeIDs, true)
 }
 
 func (s *InstanceService) Discontinue(ctx context.Context, ids []string, volumeIDs []string, deletePermanently bool) error {

--- a/pkg/verda/instances_test.go
+++ b/pkg/verda/instances_test.go
@@ -53,6 +53,35 @@ func TestInstanceService_Get(t *testing.T) {
 			t.Errorf("expected 1 instance, got %d", len(instances))
 		}
 	})
+
+	t.Run("get instances with computeId filter", func(t *testing.T) {
+		filterClient := NewTestClient(mockServer)
+		querySeen := false
+		filterClient.AddRequestMiddleware(func(next RequestHandler) RequestHandler {
+			return func(ctx *RequestContext) error {
+				if ctx.Path == "/instances" && ctx.Query.Get("computeId") == "gpu-h100" {
+					querySeen = true
+				}
+				return next(ctx)
+			}
+		})
+
+		ctx := context.Background()
+		instances, err := filterClient.Instances.GetWithOptions(ctx, InstanceListOptions{
+			Status:    StatusRunning,
+			ComputeID: "gpu-h100",
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if !querySeen {
+			t.Fatal("expected computeId query parameter to be sent")
+		}
+		if len(instances) != 1 {
+			t.Errorf("expected 1 instance, got %d", len(instances))
+		}
+	})
 }
 
 func TestInstanceService_GetByID(t *testing.T) {
@@ -267,6 +296,21 @@ func TestInstanceService_Action(t *testing.T) {
 		}
 		if len(results) != 2 {
 			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+	})
+
+	t.Run("action detailed returns results", func(t *testing.T) {
+		ctx := context.Background()
+		results, err := client.Instances.ActionDetailed(ctx, []string{"inst_123", "inst_456"}, ActionShutdown, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(results) != 2 {
+			t.Fatalf("expected 2 action results, got %d", len(results))
+		}
+		if results[0].Action != ActionShutdown {
+			t.Fatalf("expected action %s, got %s", ActionShutdown, results[0].Action)
 		}
 	})
 
@@ -521,6 +565,20 @@ func TestInstanceService_ConvenienceMethods(t *testing.T) {
 		err := client.Instances.Delete(ctx, []string{"inst_123"}, []string{"vol_123"}, true)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("delete permanently returns action results", func(t *testing.T) {
+		ctx := context.Background()
+		results, err := client.Instances.DeletePermanently(ctx, []string{"vol_123"}, "inst_123")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 action result, got %d", len(results))
+		}
+		if results[0].Status != "success" {
+			t.Fatalf("expected action status success, got %s", results[0].Status)
 		}
 	})
 

--- a/pkg/verda/instances_test.go
+++ b/pkg/verda/instances_test.go
@@ -301,7 +301,7 @@ func TestInstanceService_Action(t *testing.T) {
 
 	t.Run("action detailed returns results", func(t *testing.T) {
 		ctx := context.Background()
-		results, err := client.Instances.ActionDetailed(ctx, []string{"inst_123", "inst_456"}, ActionShutdown, nil, nil)
+		results, err := client.Instances.ActionDetailed(ctx, []string{"inst_123", "inst_456"}, ActionShutdown, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -825,19 +825,13 @@ func (ms *MockServer) handleInstanceAction(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-
-	type actionResult struct {
-		Action     string `json:"action"`
-		InstanceID string `json:"instanceId"`
-		Status     string `json:"status"`
-	}
-
-	var results []actionResult
-	for _, id := range req.ID {
-		results = append(results, actionResult{
+	results := make([]InstanceActionResult, 0, len(req.ID))
+	for _, instanceID := range req.ID {
+		results = append(results, InstanceActionResult{
+			InstanceID: instanceID,
 			Action:     req.Action,
-			InstanceID: id,
 			Status:     "success",
+			StatusCode: http.StatusAccepted,
 		})
 	}
 	writeJSON(w, results)

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -825,9 +825,18 @@ func (ms *MockServer) handleInstanceAction(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	results := make([]InstanceActionResult, 0, len(req.ID))
+
+	type instanceActionResult struct {
+		InstanceID string `json:"instanceId"`
+		Action     string `json:"action"`
+		Status     string `json:"status"`
+		Error      string `json:"error,omitempty"`
+		StatusCode int    `json:"statusCode,omitempty"`
+	}
+
+	results := make([]instanceActionResult, 0, len(req.ID))
 	for _, instanceID := range req.ID {
-		results = append(results, InstanceActionResult{
+		results = append(results, instanceActionResult{
 			InstanceID: instanceID,
 			Action:     req.Action,
 			Status:     "success",

--- a/pkg/verda/types.go
+++ b/pkg/verda/types.go
@@ -146,6 +146,12 @@ type InstanceActionResult struct {
 	StatusCode int    `json:"statusCode,omitempty"`
 }
 
+// InstanceListOptions represents the supported filters for listing instances.
+type InstanceListOptions struct {
+	Status    string
+	ComputeID string
+}
+
 // InstanceAvailability represents instance availability information
 type InstanceAvailability struct {
 	LocationCode   string   `json:"location_code"`
@@ -337,19 +343,20 @@ const (
 
 // Instance status constants
 const (
-	StatusNew          = "new"
-	StatusOrdered      = "ordered"
-	StatusProvisioning = "provisioning"
-	StatusValidating   = "validating"
-	StatusRunning      = "running"
-	StatusOffline      = "offline"
-	StatusPending      = "pending"
-	StatusDiscontinued = "discontinued"
-	StatusUnknown      = "unknown"
-	StatusNotFound     = "notfound"
-	StatusError        = "error"
-	StatusDeleting     = "deleting"
-	StatusNoCapacity   = "no_capacity"
+	StatusNew                = "new"
+	StatusOrdered            = "ordered"
+	StatusProvisioning       = "provisioning"
+	StatusValidating         = "validating"
+	StatusRunning            = "running"
+	StatusOffline            = "offline"
+	StatusPending            = "pending"
+	StatusDiscontinued       = "discontinued"
+	StatusUnknown            = "unknown"
+	StatusNotFound           = "notfound"
+	StatusError              = "error"
+	StatusDeleting           = "deleting"
+	StatusNoCapacity         = "no_capacity"
+	StatusInstallationFailed = "installation_failed"
 )
 
 // Default location (used when no location is specified)
@@ -373,6 +380,13 @@ const (
 	VolumeTypeNVMeLocalStorage  = "NVMe_Local_Storage"
 	VolumeTypeNVMeSharedCluster = "NVMe_Shared_Cluster"
 	VolumeTypeNVMeOSCluster     = "NVMe_OS_Cluster"
+)
+
+// Volume on-spot discontinue behavior constants.
+const (
+	VolumeOnSpotDiscontinueKeepDetached = "keep_detached"
+	VolumeOnSpotDiscontinueMoveToTrash  = "move_to_trash"
+	VolumeOnSpotDiscontinueDelete       = "delete_permanently"
 )
 
 // Volume status constants - these match the actual API values


### PR DESCRIPTION
## Description
 
Sync the `/v1/instances` SDK surface with the Datacrunch OpenAPI spec by adding typed list/action helpers and supporting the remaining helper functionality not already present upstream.
 
## Type of Change
 
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates
 
## Changes Made
 
- [x] Add OpenAPI-aligned instance list filters including `computeId`
- [x] Add typed action helper wrappers on top of the upstream instance action contract
- [x] Update tests, mock behavior, changelog, and branch base after rebasing onto latest upstream `main`
 
## Testing
 
- [x] Unit tests pass locally (`make test-unit`)
- [x] Integration tests pass (if applicable, `make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] All CI checks pass
 
**Test Coverage:**
Ran `go test ./pkg/verda -run 'TestInstanceService'` with Go 1.25.8.
 
## Checklist
 
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
 
## Related Issues
 
Closes #
Related to #
 
## Additional Context
 
Rebased onto the latest `verda-cloud/verdacloud-sdk-go` `main` to pick up the Go 1.25 security/vulnerability fixes.
 
---
 
**Note:** Pre-commit hooks will run automatically when you commit. Make sure to run `make check` before pushing to ensure all CI checks will pass.