### PR TITLE
change Default testing location to FIN-03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client-side request validation using `ozzo-validation` for all mutating operations
 - `ValidateCreateDeploymentRequest` and `ValidateCreateJobDeploymentRequest` extended validators
 - `IsLatestTag` helper to detect unversioned container images
+- `LocationFIN03` constant for the FIN-03 datacenter location
 
 ### Changed
 - Co-locate domain types with service files (`*_types.go`) instead of monolithic `types.go`
 - Rename `make test-unit` to `make test`, `make test-e2e` to `make test-smoke` (old names still work)
+
+### Fixed
+- Change default location from `FIN-01` to `FIN-03` for instance, cluster, and volume creation
 
 ## [v1.3.0] - 2026-03-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ newInstance, err := client.Instances.Create(ctx, verda.CreateInstanceRequest{
     Image:        "ubuntu-24.04-cuda-12.8-open-docker",
     Hostname:     "my-gpu-box",
     SSHKeyIDs:    []string{"ssh_key_id"},
-    LocationCode: verda.LocationFIN01,
+    LocationCode: verda.LocationFIN03,
 })
 
 // Control instances

--- a/example/main.go
+++ b/example/main.go
@@ -76,7 +76,7 @@ func main() {
 		fmt.Printf("Available locations:\n")
 		for _, location := range locations {
 			status := "unavailable"
-			if location.Code == verda.LocationFIN01 {
+			if location.Code == verda.LocationFIN03 {
 				status = "available"
 			}
 			fmt.Printf("- %s (%s): %s - %s\n",
@@ -102,7 +102,7 @@ func main() {
 			Hostname:     "test-instance",
 			Description:  "Test instance from Go SDK",
 			SSHKeyIDs:    []string{}, // Add your SSH key IDs here
-			LocationCode: verda.LocationFIN01,
+			LocationCode: verda.LocationFIN03,
 			Contract:     "PAY_AS_YOU_GO",
 			Pricing:      "FIXED_PRICE",
 		})

--- a/pkg/verda/clusters.go
+++ b/pkg/verda/clusters.go
@@ -34,7 +34,7 @@ func (s *ClusterService) Create(ctx context.Context, req CreateClusterRequest) (
 	}
 
 	if req.LocationCode == "" {
-		req.LocationCode = LocationFIN01
+		req.LocationCode = LocationFIN03
 	}
 
 	response, _, err := postRequest[CreateClusterResponse](ctx, s.client, "/clusters", req)

--- a/pkg/verda/clusters_test.go
+++ b/pkg/verda/clusters_test.go
@@ -95,7 +95,7 @@ func TestClusterService_Create(t *testing.T) {
 			Hostname:          "test-cluster-full",
 			Description:       "Test cluster with full config",
 			SSHKeyIDs:         []string{"key_123", "key_456"},
-			LocationCode:      LocationFIN01,
+			LocationCode:      LocationFIN03,
 			Contract:          "PAY_AS_YOU_GO",
 			StartupScriptID:   &startupScriptID,
 			AutoRentExtension: &autoRentExtension,
@@ -234,7 +234,7 @@ func TestClusterService_GetAvailabilities(t *testing.T) {
 
 	t.Run("get cluster availabilities for specific location", func(t *testing.T) {
 		ctx := context.Background()
-		availabilities, err := client.Clusters.GetAvailabilities(ctx, LocationFIN01)
+		availabilities, err := client.Clusters.GetAvailabilities(ctx, LocationFIN03)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -264,7 +264,7 @@ func TestClusterService_CheckClusterTypeAvailability(t *testing.T) {
 
 	t.Run("check cluster type availability for specific location", func(t *testing.T) {
 		ctx := context.Background()
-		available, err := client.Clusters.CheckClusterTypeAvailability(ctx, "8V100.48V", LocationFIN01)
+		available, err := client.Clusters.CheckClusterTypeAvailability(ctx, "8V100.48V", LocationFIN03)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/verda/instance_availability_test.go
+++ b/pkg/verda/instance_availability_test.go
@@ -38,7 +38,7 @@ func TestInstanceAvailabilityService_GetAllAvailabilities(t *testing.T) {
 
 	t.Run("get availabilities for specific location", func(t *testing.T) {
 		ctx := context.Background()
-		availabilities, err := client.InstanceAvailability.GetAllAvailabilities(ctx, false, LocationFIN01)
+		availabilities, err := client.InstanceAvailability.GetAllAvailabilities(ctx, false, LocationFIN03)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -62,7 +62,7 @@ func TestInstanceAvailabilityService_GetAllAvailabilities(t *testing.T) {
 
 	t.Run("get spot availabilities for specific location", func(t *testing.T) {
 		ctx := context.Background()
-		availabilities, err := client.InstanceAvailability.GetAllAvailabilities(ctx, true, LocationFIN01)
+		availabilities, err := client.InstanceAvailability.GetAllAvailabilities(ctx, true, LocationFIN03)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -139,7 +139,7 @@ func TestInstanceAvailabilityService_GetInstanceTypeAvailability(t *testing.T) {
 
 	t.Run("check availability for specific location", func(t *testing.T) {
 		ctx := context.Background()
-		available, err := client.InstanceAvailability.GetInstanceTypeAvailability(ctx, "1V100.6V", false, LocationFIN01)
+		available, err := client.InstanceAvailability.GetInstanceTypeAvailability(ctx, "1V100.6V", false, LocationFIN03)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -150,7 +150,7 @@ func TestInstanceAvailabilityService_GetInstanceTypeAvailability(t *testing.T) {
 
 	t.Run("check availability with all parameters", func(t *testing.T) {
 		ctx := context.Background()
-		available, err := client.InstanceAvailability.GetInstanceTypeAvailability(ctx, "1H100.80S.22V", true, LocationFIN01)
+		available, err := client.InstanceAvailability.GetInstanceTypeAvailability(ctx, "1H100.80S.22V", true, LocationFIN03)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/verda/instance_types_test.go
+++ b/pkg/verda/instance_types_test.go
@@ -196,7 +196,7 @@ func TestInstanceTypesService_GetByInstanceType(t *testing.T) {
 
 	t.Run("get instance type with all parameters", func(t *testing.T) {
 		ctx := context.Background()
-		instanceType, err := client.InstanceTypes.GetByInstanceType(ctx, "1H100.80S.22V", true, LocationFIN01, "usd")
+		instanceType, err := client.InstanceTypes.GetByInstanceType(ctx, "1H100.80S.22V", true, LocationFIN03, "usd")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/pkg/verda/instances.go
+++ b/pkg/verda/instances.go
@@ -46,7 +46,7 @@ func (s *InstanceService) Create(ctx context.Context, req CreateInstanceRequest)
 	}
 
 	if req.LocationCode == "" {
-		req.LocationCode = LocationFIN01
+		req.LocationCode = LocationFIN03
 	}
 
 	if req.SSHKeyIDs == nil {

--- a/pkg/verda/instances_test.go
+++ b/pkg/verda/instances_test.go
@@ -120,8 +120,8 @@ func TestInstanceService_Create(t *testing.T) {
 		}
 
 		// Should set default location
-		if instance.Location != LocationFIN01 {
-			t.Errorf("expected location '%s', got '%s'", LocationFIN01, instance.Location)
+		if instance.Location != LocationFIN03 {
+			t.Errorf("expected location '%s', got '%s'", LocationFIN03, instance.Location)
 		}
 	})
 

--- a/pkg/verda/locations.go
+++ b/pkg/verda/locations.go
@@ -9,9 +9,10 @@ type Location struct {
 	CountryCode string `json:"country_code"`
 }
 
-// Default location (used when no location is specified)
+// Location constants
 const (
 	LocationFIN01 = "FIN-01"
+	LocationFIN03 = "FIN-03"
 )
 
 type LocationService struct {

--- a/pkg/verda/locations_test.go
+++ b/pkg/verda/locations_test.go
@@ -25,8 +25,8 @@ func TestLocationsService_Get(t *testing.T) {
 		}
 
 		location := locations[0]
-		if location.Code != LocationFIN01 {
-			t.Errorf("expected location code '%s', got '%s'", LocationFIN01, location.Code)
+		if location.Code != LocationFIN03 {
+			t.Errorf("expected location code '%s', got '%s'", LocationFIN03, location.Code)
 		}
 
 		if location.Name == "" {

--- a/pkg/verda/services_test.go
+++ b/pkg/verda/services_test.go
@@ -201,12 +201,12 @@ func TestLocationService_Get(t *testing.T) {
 		}
 
 		location := locations[0]
-		if location.Code != LocationFIN01 {
-			t.Errorf("expected location code '%s', got '%s'", LocationFIN01, location.Code)
+		if location.Code != LocationFIN03 {
+			t.Errorf("expected location code '%s', got '%s'", LocationFIN03, location.Code)
 		}
 
-		if location.Name != "Finland 01" {
-			t.Errorf("expected location name 'Finland 01', got '%s'", location.Name)
+		if location.Name != "Finland 03" {
+			t.Errorf("expected location name 'Finland 03', got '%s'", location.Name)
 		}
 
 		if location.CountryCode != "FI" {

--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -441,7 +441,7 @@ type ClusterImage struct {
 const (
 	StatusRunning = "running"
 	StatusPending = "pending"
-	LocationFIN01 = "FIN-01"
+	LocationFIN03 = "FIN-03"
 	pathInstances = "/instances"
 	// nolint:gosec // G101: This is a URL path, not a credential
 	pathOAuth2Token = "/oauth2/token"
@@ -691,7 +691,7 @@ func (ms *MockServer) handleGetInstances(w http.ResponseWriter, _ *http.Request)
 			Storage:         map[string]interface{}{"description": "100GB SSD"},
 			Hostname:        "test-instance",
 			Description:     "Test instance",
-			Location:        LocationFIN01,
+			Location:        LocationFIN03,
 			PricePerHour:    0.50,
 			IsSpot:          false,
 			InstanceType:    "1V100.6V",
@@ -738,7 +738,7 @@ func (ms *MockServer) handleGetInstance(w http.ResponseWriter, r *http.Request) 
 		Storage:         map[string]interface{}{"description": "100GB SSD"},
 		Hostname:        "test-instance",
 		Description:     "Test instance",
-		Location:        LocationFIN01,
+		Location:        LocationFIN03,
 		PricePerHour:    0.50,
 		IsSpot:          false,
 		InstanceType:    "1V100.6V",
@@ -768,7 +768,7 @@ func (ms *MockServer) handleCreateInstance(w http.ResponseWriter, r *http.Reques
 	// Use LocationCode if provided, otherwise default
 	location := req.LocationCode
 	if location == "" {
-		location = LocationFIN01
+		location = LocationFIN03
 	}
 
 	// Use Contract and Pricing if provided, otherwise use defaults
@@ -875,8 +875,8 @@ func (ms *MockServer) handleGetLocations(w http.ResponseWriter, _ *http.Request)
 
 	locations := []Location{
 		{
-			Code:        LocationFIN01,
-			Name:        "Finland 01",
+			Code:        LocationFIN03,
+			Name:        "Finland 03",
 			Country:     "Finland",
 			CountryCode: "FI",
 			Available:   true,
@@ -1172,7 +1172,7 @@ func (ms *MockServer) handleGetClusters(w http.ResponseWriter, _ *http.Request) 
 			GPU:          map[string]interface{}{"description": "8x Tesla V100 16GB", "number_of_gpus": 8},
 			Memory:       map[string]interface{}{"description": "256GB RAM", "size_in_gigabytes": 256},
 			GPUMemory:    map[string]interface{}{"description": "128GB GPU RAM", "size_in_gigabytes": 128},
-			Location:     LocationFIN01,
+			Location:     LocationFIN03,
 			Contract:     "PAY_AS_YOU_GO",
 		},
 	}
@@ -1206,7 +1206,7 @@ func (ms *MockServer) handleGetCluster(w http.ResponseWriter, r *http.Request) {
 		GPU:          map[string]interface{}{"description": "8x Tesla V100 16GB", "number_of_gpus": 8},
 		Memory:       map[string]interface{}{"description": "256GB RAM", "size_in_gigabytes": 256},
 		GPUMemory:    map[string]interface{}{"description": "128GB GPU RAM", "size_in_gigabytes": 128},
-		Location:     LocationFIN01,
+		Location:     LocationFIN03,
 		Contract:     "PAY_AS_YOU_GO",
 	}
 
@@ -1275,7 +1275,7 @@ func (ms *MockServer) handleGetClusterAvailabilities(w http.ResponseWriter, _ *h
 
 	availabilities := []ClusterAvailability{
 		{
-			LocationCode:   LocationFIN01,
+			LocationCode:   LocationFIN03,
 			Availabilities: []string{"8V100.48V", "16H200", "32H200"},
 		},
 	}
@@ -1521,7 +1521,7 @@ func (ms *MockServer) handleGetInstanceAvailabilities(w http.ResponseWriter, _ *
 
 	availabilities := []LocationAvailability{
 		{
-			LocationCode:   LocationFIN01,
+			LocationCode:   LocationFIN03,
 			Availabilities: []string{"1V100.6V", "8V100.48V"},
 		},
 		{

--- a/pkg/verda/volumes.go
+++ b/pkg/verda/volumes.go
@@ -48,7 +48,7 @@ func (s *VolumeService) CreateVolume(ctx context.Context, req VolumeCreateReques
 		return "", err
 	}
 	if req.LocationCode == "" {
-		req.LocationCode = LocationFIN01
+		req.LocationCode = LocationFIN03
 	}
 
 	return s.createVolumeWithPlainTextResponse(ctx, req)

--- a/pkg/verda/volumes_test.go
+++ b/pkg/verda/volumes_test.go
@@ -202,7 +202,7 @@ func TestVolumeService_CreateVolume(t *testing.T) {
 	t.Run("create volume", func(t *testing.T) {
 		req := VolumeCreateRequest{
 			Type:         VolumeTypeNVMe,
-			LocationCode: LocationFIN01,
+			LocationCode: LocationFIN03,
 			Size:         100,
 			Name:         "New Test Volume",
 		}
@@ -413,7 +413,7 @@ func TestVolumeService_CloneVolume(t *testing.T) {
 	t.Run("clone volume", func(t *testing.T) {
 		req := VolumeCloneRequest{
 			Name:         "Cloned Volume",
-			LocationCode: LocationFIN01,
+			LocationCode: LocationFIN03,
 		}
 
 		ctx := context.Background()
@@ -534,7 +534,7 @@ func TestVolumeService_ErrorHandling(t *testing.T) {
 
 		req := VolumeCreateRequest{
 			Type:         VolumeTypeNVMe,
-			LocationCode: LocationFIN01,
+			LocationCode: LocationFIN03,
 			Size:         0, // Invalid size
 			Name:         "Invalid Volume",
 		}

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -152,7 +152,7 @@ func TestCreateVolume_Integration(t *testing.T) {
 	ctx := context.Background()
 	volumeID, err := client.Volumes.CreateVolume(ctx, verda.VolumeCreateRequest{
 		Type:         verda.VolumeTypeNVMe,
-		LocationCode: verda.LocationFIN01,
+		LocationCode: verda.LocationFIN03,
 		Size:         50,
 		Name:         "integration-test-volume",
 	})
@@ -257,7 +257,7 @@ func TestVolumeLifecycle_Integration(t *testing.T) {
 	for _, config := range volumeConfigs {
 		volumeID, err := client.Volumes.CreateVolume(ctx, verda.VolumeCreateRequest{
 			Type:         config.volumeType,
-			LocationCode: verda.LocationFIN01,
+			LocationCode: verda.LocationFIN03,
 			Size:         config.size,
 			Name:         config.name,
 		})
@@ -342,7 +342,7 @@ func TestVolumeRename_Integration(t *testing.T) {
 	ctx := context.Background()
 	volumeID, err := client.Volumes.CreateVolume(ctx, verda.VolumeCreateRequest{
 		Type:         verda.VolumeTypeNVMe,
-		LocationCode: verda.LocationFIN01,
+		LocationCode: verda.LocationFIN03,
 		Size:         50,
 		Name:         "test-volume-rename-original",
 	})
@@ -403,7 +403,7 @@ func TestVolumeResize_Integration(t *testing.T) {
 	ctx := context.Background()
 	volumeID, err := client.Volumes.CreateVolume(ctx, verda.VolumeCreateRequest{
 		Type:         verda.VolumeTypeNVMe,
-		LocationCode: verda.LocationFIN01,
+		LocationCode: verda.LocationFIN03,
 		Size:         50,
 		Name:         "test-volume-resize",
 	})
@@ -464,7 +464,7 @@ func TestVolumeClone_Integration(t *testing.T) {
 	ctx := context.Background()
 	originalVolumeID, err := client.Volumes.CreateVolume(ctx, verda.VolumeCreateRequest{
 		Type:         verda.VolumeTypeNVMe,
-		LocationCode: verda.LocationFIN01,
+		LocationCode: verda.LocationFIN03,
 		Size:         50,
 		Name:         "test-volume-original",
 	})
@@ -490,7 +490,7 @@ func TestVolumeClone_Integration(t *testing.T) {
 	// Clone the volume
 	clonedVolumeID, err := client.Volumes.CloneVolume(ctx, originalVolumeID, verda.VolumeCloneRequest{
 		Name:         "test-volume-cloned",
-		LocationCode: verda.LocationFIN01,
+		LocationCode: verda.LocationFIN03,
 	})
 
 	if err != nil {


### PR DESCRIPTION
### Added
- Client-side request validation using `ozzo-validation` for all mutating operations
- `ValidateCreateDeploymentRequest` and `ValidateCreateJobDeploymentRequest` extended validators
- `IsLatestTag` helper to detect unversioned container images
- `LocationFIN03` constant for the FIN-03 datacenter location

### Changed
- Co-locate domain types with service files (`*_types.go`) instead of monolithic `types.go`
- Rename `make test-unit` to `make test`, `make test-e2e` to `make test-smoke` (old names still work)

### Fixed
- Change default location from `FIN-01` to `FIN-03` for instance, cluster, and volume creation

## Description

<!-- Brief description of what this PR does and why -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [x] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates

## Changes Made

-
-

## Checklist

- [x] I have updated the `## [Unreleased]` section in `CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally (`make test`)
- [ ] My changes generate no new warnings or errors

## Related Issues

<!-- Link any related issues: Closes #123, Related to #456 -->

## Additional Context

<!-- Screenshots, benchmarks, or other context (optional) -->
