### PR TITLE
update get volume type response to make sure backward compatiable

### DIFF
--- a/pkg/verda/testutil/mock_server.go
+++ b/pkg/verda/testutil/mock_server.go
@@ -262,8 +262,9 @@ type VolumeType struct {
 }
 
 type VolumeTypePrice struct {
-	MonthlyPerGB float64 `json:"monthly_per_gb"`
-	Currency     string  `json:"currency"`
+	PricePerMonthPerGB float64 `json:"price_per_month_per_gb"`
+	CPSPerGB           float64 `json:"cps_per_gb"`
+	Currency           string  `json:"currency"`
 }
 
 type Image struct {
@@ -1115,8 +1116,9 @@ func (ms *MockServer) handleGetVolumeTypes(w http.ResponseWriter, _ *http.Reques
 		{
 			Type: "NVMe",
 			Price: VolumeTypePrice{
-				MonthlyPerGB: 0.12,
-				Currency:     "USD",
+				PricePerMonthPerGB: 0.12,
+				CPSPerGB:           4.5662100456621005e-8,
+				Currency:           "usd",
 			},
 			IsSharedFS:           false,
 			BurstBandwidth:       2000,
@@ -1127,8 +1129,9 @@ func (ms *MockServer) handleGetVolumeTypes(w http.ResponseWriter, _ *http.Reques
 		{
 			Type: "NVMe_Shared",
 			Price: VolumeTypePrice{
-				MonthlyPerGB: 0.15,
-				Currency:     "USD",
+				PricePerMonthPerGB: 0.15,
+				CPSPerGB:           5.707762557077625e-8,
+				Currency:           "usd",
 			},
 			IsSharedFS:           true,
 			BurstBandwidth:       3000,
@@ -1139,8 +1142,9 @@ func (ms *MockServer) handleGetVolumeTypes(w http.ResponseWriter, _ *http.Reques
 		{
 			Type: "HDD",
 			Price: VolumeTypePrice{
-				MonthlyPerGB: 0.05,
-				Currency:     "USD",
+				PricePerMonthPerGB: 0.05,
+				CPSPerGB:           1.902587519025875e-8,
+				Currency:           "usd",
 			},
 			IsSharedFS:           false,
 			BurstBandwidth:       500,

--- a/pkg/verda/volume_types.go
+++ b/pkg/verda/volume_types.go
@@ -2,6 +2,7 @@ package verda
 
 import (
 	"context"
+	"encoding/json"
 )
 
 // VolumeType represents available volume type specifications
@@ -18,8 +19,44 @@ type VolumeType struct {
 
 // VolumeTypePrice represents the pricing structure for a volume type
 type VolumeTypePrice struct {
-	MonthlyPerGB float64 `json:"monthly_per_gb"`
+	// PricePerMonthPerGB matches the current API response field `price_per_month_per_gb`.
+	// New code should use this field.
+	PricePerMonthPerGB float64 `json:"price_per_month_per_gb"`
+	CPSPerGB           float64 `json:"cps_per_gb"`
+	// Deprecated: use PricePerMonthPerGB. MonthlyPerGB is a compatibility alias for older SDK callers and is not part of the current API payload.
+	MonthlyPerGB float64 `json:"-"`
 	Currency     string  `json:"currency"`
+}
+
+// UnmarshalJSON accepts both the current API field `price_per_month_per_gb`
+// and the legacy field `monthly_per_gb`, but new code should read PricePerMonthPerGB.
+func (p *VolumeTypePrice) UnmarshalJSON(data []byte) error {
+	type priceAlias struct {
+		PricePerMonthPerGB *float64 `json:"price_per_month_per_gb"`
+		MonthlyPerGB       *float64 `json:"monthly_per_gb"`
+		CPSPerGB           float64  `json:"cps_per_gb"`
+		Currency           string   `json:"currency"`
+	}
+
+	var raw priceAlias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	p.CPSPerGB = raw.CPSPerGB
+	p.Currency = raw.Currency
+
+	switch {
+	case raw.PricePerMonthPerGB != nil:
+		p.PricePerMonthPerGB = *raw.PricePerMonthPerGB
+	case raw.MonthlyPerGB != nil:
+		p.PricePerMonthPerGB = *raw.MonthlyPerGB
+	default:
+		p.PricePerMonthPerGB = 0
+	}
+
+	p.MonthlyPerGB = p.PricePerMonthPerGB
+	return nil
 }
 
 type VolumeTypeService struct {

--- a/pkg/verda/volume_types_test.go
+++ b/pkg/verda/volume_types_test.go
@@ -2,6 +2,7 @@ package verda
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/verda-cloud/verdacloud-sdk-go/pkg/verda/testutil"
@@ -30,8 +31,11 @@ func TestVolumeTypeService_GetAllVolumeTypes(t *testing.T) {
 			if vt.Type == "" {
 				t.Error("expected volume type to have a Type")
 			}
-			if vt.Price.MonthlyPerGB <= 0 {
+			if vt.Price.PricePerMonthPerGB <= 0 {
 				t.Error("expected volume type to have a positive price per GB")
+			}
+			if vt.Price.MonthlyPerGB != vt.Price.PricePerMonthPerGB {
+				t.Error("expected compatibility price alias to match canonical price")
 			}
 			if vt.Price.Currency == "" {
 				t.Error("expected volume type to have a Currency")
@@ -54,8 +58,11 @@ func TestVolumeTypeService_GetAllVolumeTypes(t *testing.T) {
 				if vt.Type == "" {
 					t.Errorf("volume type %d missing Type", i)
 				}
-				if vt.Price.MonthlyPerGB <= 0 {
-					t.Errorf("volume type %d has invalid price: %f", i, vt.Price.MonthlyPerGB)
+				if vt.Price.PricePerMonthPerGB <= 0 {
+					t.Errorf("volume type %d has invalid price: %f", i, vt.Price.PricePerMonthPerGB)
+				}
+				if vt.Price.MonthlyPerGB != vt.Price.PricePerMonthPerGB {
+					t.Errorf("volume type %d has mismatched compatibility price: %f vs %f", i, vt.Price.MonthlyPerGB, vt.Price.PricePerMonthPerGB)
 				}
 				if vt.Price.Currency == "" {
 					t.Errorf("volume type %d missing Currency", i)
@@ -114,9 +121,9 @@ func TestVolumeTypeService_GetAllVolumeTypes(t *testing.T) {
 		if len(volumeTypes) > 0 {
 			for i, vt := range volumeTypes {
 				// Verify price object is populated
-				if vt.Price.MonthlyPerGB <= 0 {
+				if vt.Price.PricePerMonthPerGB <= 0 {
 					t.Errorf("volume type %d (%s) has invalid monthly price: %f",
-						i, vt.Type, vt.Price.MonthlyPerGB)
+						i, vt.Type, vt.Price.PricePerMonthPerGB)
 				}
 				if vt.Price.Currency != "USD" && vt.Price.Currency != "EUR" && vt.Price.Currency != "" {
 					t.Logf("volume type %d (%s) has unusual currency: %s",
@@ -124,6 +131,48 @@ func TestVolumeTypeService_GetAllVolumeTypes(t *testing.T) {
 				}
 			}
 		}
+	})
+
+	t.Run("decode current and legacy price fields", func(t *testing.T) {
+		t.Run("current api payload", func(t *testing.T) {
+			var price VolumeTypePrice
+			err := json.Unmarshal([]byte(`{
+				"price_per_month_per_gb": 0.2,
+				"cps_per_gb": 7.6103500761035e-8,
+				"currency": "usd"
+			}`), &price)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if price.PricePerMonthPerGB != 0.2 {
+				t.Fatalf("expected canonical monthly price to be decoded, got %f", price.PricePerMonthPerGB)
+			}
+			if price.MonthlyPerGB != 0.2 {
+				t.Fatalf("expected compatibility alias to be populated, got %f", price.MonthlyPerGB)
+			}
+			if price.CPSPerGB <= 0 {
+				t.Fatalf("expected cps_per_gb to be decoded, got %f", price.CPSPerGB)
+			}
+		})
+
+		t.Run("legacy payload", func(t *testing.T) {
+			var price VolumeTypePrice
+			err := json.Unmarshal([]byte(`{
+				"monthly_per_gb": 0.12,
+				"currency": "USD"
+			}`), &price)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if price.PricePerMonthPerGB != 0.12 {
+				t.Fatalf("expected legacy monthly price to map to canonical field, got %f", price.PricePerMonthPerGB)
+			}
+			if price.MonthlyPerGB != 0.12 {
+				t.Fatalf("expected legacy monthly price to populate compatibility alias, got %f", price.MonthlyPerGB)
+			}
+		})
 	})
 
 	t.Run("verify performance metrics", func(t *testing.T) {

--- a/test/integration/volume_types_test.go
+++ b/test/integration/volume_types_test.go
@@ -28,14 +28,17 @@ func TestVolumeTypesIntegration(t *testing.T) {
 			for i, vt := range volumeTypes {
 				if i < 5 { // Log first 5
 					t.Logf("Volume Type: %s - Price: %f %s/GB/month, Shared: %v, IOPS: %s",
-						vt.Type, vt.Price.MonthlyPerGB, vt.Price.Currency, vt.IsSharedFS, vt.IOPS)
+						vt.Type, vt.Price.PricePerMonthPerGB, vt.Price.Currency, vt.IsSharedFS, vt.IOPS)
 				}
 				if vt.Type == "" {
 					t.Errorf("volume type %d missing Type", i)
 				}
 				// Note: Pricing might be 0 in staging environment
-				if vt.Price.MonthlyPerGB <= 0 {
-					t.Logf("⚠️  volume type %d (%s) has zero/invalid price: %f (this may be expected in staging)", i, vt.Type, vt.Price.MonthlyPerGB)
+				if vt.Price.PricePerMonthPerGB <= 0 {
+					t.Logf("⚠️  volume type %d (%s) has zero/invalid price: %f (this may be expected in staging)", i, vt.Type, vt.Price.PricePerMonthPerGB)
+				}
+				if vt.Price.MonthlyPerGB != vt.Price.PricePerMonthPerGB {
+					t.Errorf("volume type %d has mismatched compatibility price fields", i)
 				}
 				if vt.IOPS == "" {
 					t.Errorf("volume type %d missing IOPS", i)
@@ -118,13 +121,13 @@ func TestVolumeTypesIntegration(t *testing.T) {
 		zeroPriceCount := 0
 		for _, vt := range volumeTypes {
 			// Note: Pricing might be 0 in staging environment
-			if vt.Price.MonthlyPerGB <= 0 {
-				t.Logf("⚠️  volume type %s has zero/invalid price: %f (may be expected in staging)", vt.Type, vt.Price.MonthlyPerGB)
+			if vt.Price.PricePerMonthPerGB <= 0 {
+				t.Logf("⚠️  volume type %s has zero/invalid price: %f (may be expected in staging)", vt.Type, vt.Price.PricePerMonthPerGB)
 				zeroPriceCount++
 			}
 
 			// Log pricing for manual verification
-			t.Logf("Volume type %s: %f %s/GB/month", vt.Type, vt.Price.MonthlyPerGB, vt.Price.Currency)
+			t.Logf("Volume type %s: %f %s/GB/month", vt.Type, vt.Price.PricePerMonthPerGB, vt.Price.Currency)
 		}
 
 		// Only warn if ALL prices are zero - this is likely a staging limitation


### PR DESCRIPTION
## Description

Fix volume type price decoding to match the current API response shape.

The API now returns `price_per_month_per_gb` (and `cps_per_gb`) instead of `monthly_per_gb`. This PR updates the SDK to read the new field while preserving backward compatibility for existing callers that still access `MonthlyPerGB`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ✅ Test updates

> **Note:** Use [conventional commit](https://www.conventionalcommits.org/) messages (e.g. `feat:`, `fix:`, `chore:`).
> The changelog is auto-generated from commit messages at release time.

## Changes Made

- Updated `VolumeTypePrice` to use `price_per_month_per_gb` as the canonical API field and added `cps_per_gb`
- Added custom JSON unmarshalling to support both the current API field (`price_per_month_per_gb`) and the legacy field (`monthly_per_gb`)
- Kept `MonthlyPerGB` as a deprecated compatibility alias populated from the canonical value
- Updated mock server responses to match the current API payload
- Expanded unit and integration tests to verify both current and legacy payload decoding, and to assert compatibility behavior

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally (`make test`)
- [ ] My changes generate no new warnings or errors

## Related Issues

<!-- Link any related issues: Closes #123, Related to #456 -->

## Additional Context

This change is intended to be backward compatible for SDK consumers. Existing code that reads `MonthlyPerGB` should continue to work, while new code should prefer `PricePerMonthPerGB`.
