### PR TITLE
fix(ci): use release branch workflow instead of pushing directly to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,18 @@ jobs:
       - name: Run make release
         run: make release VERSION=${{ github.event.inputs.version }}
 
-      - name: Commit and tag
+      - name: Commit, tag, and push release branch
         run: |
+          VERSION="${{ github.event.inputs.version }}"
+          BRANCH="release/${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}
+          git checkout -b "${BRANCH}"
           git add -A
-          git commit -m "chore(release): ${{ github.event.inputs.version }}"
-          git tag ${{ github.event.inputs.version }}
-          git push origin main --tags
+          git commit -m "chore(release): ${VERSION}"
+          git tag "${VERSION}"
+          git push origin "${BRANCH}" --tags
 
       - name: Extract changelog for release
         id: changelog
@@ -65,8 +69,19 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh release create ${{ github.event.inputs.version }} \
             --title "${{ github.event.inputs.version }}" \
             --notes-file /tmp/release-notes.md
+
+      - name: Create PR to merge release into main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          gh pr create \
+            --base main \
+            --head "release/${VERSION}" \
+            --title "chore(release): ${VERSION}" \
+            --body "Automated release PR for ${VERSION}. Merges changelog and version updates into main."


### PR DESCRIPTION
Push to a release branch with proper RELEASE_TOKEN auth, create a PR to merge back into main, avoiding branch protection failures.

## Description

<!-- Brief description of what this PR does and why -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration/build changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ✅ Test updates

> **Note:** Use [conventional commit](https://www.conventionalcommits.org/) messages (e.g. `feat:`, `fix:`, `chore:`).
> The changelog is auto-generated from commit messages at release time.

## Changes Made

-
-

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally (`make test`)
- [ ] My changes generate no new warnings or errors

## Related Issues

<!-- Link any related issues: Closes #123, Related to #456 -->

## Additional Context

<!-- Screenshots, benchmarks, or other context (optional) -->
